### PR TITLE
Add .claude/ to .gitignore for workspace command symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Thumbs.db
 .vscode/
 *.swp
 *.swo
+
+# Claude Code local config (symlinks to workspace commands)
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` so local symlinks to workspace-level Claude commands are not tracked

## Context
Workspace-level Claude commands (`/issue-to-merge`, `/sequential-issues`) live in the parent `manasight` repo at `.claude/commands/`. Each child repo (like this one) symlinks them into `.claude/commands/` so Claude Code discovers them when working inside the repo. Since symlinks use relative paths that are machine-specific, the `.claude/` directory is gitignored.

### Setup (one-time, per clone)
```bash
mkdir -p .claude/commands
ln -s ../../../.claude/commands/issue-to-merge.md .claude/commands/issue-to-merge.md
ln -s ../../../.claude/commands/sequential-issues.md .claude/commands/sequential-issues.md
```

Replaces PR #2 which was closed because its workflow files were regressions of fixes already on main via PR #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)