### PR TITLE
Fix manasight/manasight-docs#136: Timestamp parser (all locale formats)

### DIFF
--- a/src/log/timestamp.rs
+++ b/src/log/timestamp.rs
@@ -81,6 +81,15 @@ pub enum TimestampError {
 /// All timestamps are treated as UTC (MTGA does not include timezone
 /// information in log entry headers).
 ///
+/// # Ambiguity
+///
+/// When day and month are both `<= 12` and the separator is `/` (for example
+/// `02/05/2025 14:30:00`), US format (`M/d/yyyy`) is tried before European
+/// (`dd/MM/yyyy`). The input above would therefore be interpreted as
+/// February 5, not May 2. There is no way to resolve this ambiguity
+/// without out-of-band locale information; consumers targeting European
+/// locales should be aware of this silent tie-break.
+///
 /// # Errors
 ///
 /// Returns [`TimestampError::UnrecognizedFormat`] if no format matches,
@@ -398,7 +407,7 @@ mod tests {
 
         #[test]
         fn test_parse_epoch_millis_out_of_range_returns_error() {
-            // i64::MAX seconds is far beyond DateTime's representable range.
+            // i64::MAX milliseconds is far beyond DateTime's representable range.
             let err = parse_epoch_millis(i64::MAX);
             assert!(matches!(
                 err,


### PR DESCRIPTION
## Summary
- Implement timestamp parsing for all 11 known MTGA locale-dependent formats (5 date patterns × 2 time modes + ISO 8601 with T separator)
- Add payload timestamp parsers: epoch milliseconds, .NET ticks, and ISO 8601 strings
- All timestamps normalized to UTC with typed error handling preserving raw input for diagnostics

## Changes Made
- `src/log/timestamp.rs`: Full implementation with `parse_log_timestamp`, `parse_epoch_millis`, `parse_dotnet_ticks`, `parse_iso8601`, and `TimestampError` error type
- No new dependencies required (uses existing `chrono` and `thiserror`)

## Testing
- All tests passing (107 tests, 40 new)
- Linting clean, formatted
- Code coverage: 99.21% coverage, 125/126 lines covered, +1.23% change in coverage

Closes manasight/manasight-docs#136

🤖 Generated with [Claude Code](https://claude.com/claude-code)