### PR TITLE
Fix manasight/manasight-docs#145: Game result parser

### DIFF
--- a/src/parsers/game_result.rs
+++ b/src/parsers/game_result.rs
@@ -222,8 +222,12 @@ fn extract_json_from_body(body: &str) -> Option<&str> {
 
     let candidate = &body[json_start..];
 
-    let open_byte = candidate.as_bytes().first().copied()?;
-    let close_byte = if open_byte == b'{' { b'}' } else { b']' };
+    let first_byte = candidate.as_bytes().first().copied()?;
+    let (open_char, close_char) = if first_byte == b'{' {
+        ('{', '}')
+    } else {
+        ('[', ']')
+    };
 
     let mut depth: i32 = 0;
     let mut in_string = false;
@@ -242,10 +246,10 @@ fn extract_json_from_body(body: &str) -> Option<&str> {
             '"' => {
                 in_string = !in_string;
             }
-            c if !in_string && c as u8 == open_byte => {
+            c if !in_string && c == open_char => {
                 depth += 1;
             }
-            c if !in_string && c as u8 == close_byte => {
+            c if !in_string && c == close_char => {
                 depth -= 1;
                 if depth == 0 {
                     end_pos = Some(i + 1);


### PR DESCRIPTION
## Summary
- Implement game result parser for `LogBusinessEvents` entries with `WinningType`
- Class 3 (Post-Game Batch) event that triggers batch finalization in desktop subscribers
- Discriminates game results from draft pick business events sharing the same `LogBusinessEvents` container

## Changes Made
- `src/parsers/game_result.rs`: Full parser implementation (was a stub with module doc only)
  - `try_parse()` entry point matching `LogBusinessEvents` + `WinningType`
  - `build_payload()` extracting: WinningType, WinningTeamId, WinningReason, GameNumber, StartingTeamId, MatchId, EventId
  - `has_winning_type()` checking top-level, Params-wrapped, and array formats
  - `extract_json_from_body()` that skips `[UnityCrossThreadLogger]` header prefix to avoid false bracket matches
  - 36 unit tests across 8 test modules (basic parsing, Params-wrapped, array format, metadata, non-matching, performance class, missing fields, timestamp in header)

## Testing
- All 464 tests passing (`cargo test --all-features`)
- Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- Format verified (`cargo fmt --all -- --check`)

## Stacked PR
Base: `issue/144-client-action-parsers` — merge in order after earlier PRs.

Fixes manasight/manasight-docs#145

🤖 Generated with [Claude Code](https://claude.com/claude-code)