### PR TITLE
Fix manasight/manasight-docs#147: Human draft parser + draft complete

### DIFF
--- a/src/parsers/draft/complete.rs
+++ b/src/parsers/draft/complete.rs
@@ -1,0 +1,530 @@
+//! Draft completion parser for `Draft_CompleteDraft` events.
+//!
+//! When a draft finishes (all picks made), the log emits a
+//! `Draft_CompleteDraft` entry that links the draft ID to the event
+//! and marks the draft as finished.
+//!
+//! | Signature | Meaning | Key Fields |
+//! |-----------|---------|------------|
+//! | `Draft_CompleteDraft` | Draft finished | `DraftId`, `EventName` |
+//!
+//! This is a Class 2 (Durable Per-Event) event. The completion signal
+//! must survive crashes to ensure the draft record is finalized.
+
+use crate::events::{DraftCompleteEvent, EventMetadata, GameEvent};
+use crate::log::entry::LogEntry;
+
+/// Marker for draft completion events.
+///
+/// `Draft_CompleteDraft` appears in the log when the player finishes
+/// drafting all cards (all 42 picks made).
+const COMPLETE_DRAFT_MARKER: &str = "Draft_CompleteDraft";
+
+/// Attempts to parse a [`LogEntry`] as a draft completion event.
+///
+/// Returns `Some(GameEvent::DraftComplete(_))` if the entry matches the
+/// `Draft_CompleteDraft` signature, or `None` if it does not match.
+///
+/// The `timestamp` is used to construct [`EventMetadata`] for the resulting
+/// event. Callers are responsible for parsing the timestamp from the log
+/// entry header before invoking this function.
+pub fn try_parse(entry: &LogEntry, timestamp: chrono::DateTime<chrono::Utc>) -> Option<GameEvent> {
+    let body = &entry.body;
+
+    if !body.contains(COMPLETE_DRAFT_MARKER) {
+        return None;
+    }
+
+    let json_str = extract_json_from_body(body)?;
+
+    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            ::log::warn!("Draft_CompleteDraft: malformed JSON payload: {e}");
+            return None;
+        }
+    };
+
+    let payload = build_payload(&parsed);
+    let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
+    Some(GameEvent::DraftComplete(DraftCompleteEvent::new(
+        metadata, payload,
+    )))
+}
+
+/// Builds a structured payload from the draft completion event.
+///
+/// Extracts key fields into a flat payload for downstream consumers.
+/// Falls back to empty/default values for any missing fields.
+fn build_payload(parsed: &serde_json::Value) -> serde_json::Value {
+    let draft_id = parsed
+        .get("DraftId")
+        .or_else(|| parsed.get("draftId"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    let event_name = parsed
+        .get("EventName")
+        .or_else(|| parsed.get("InternalEventName"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    serde_json::json!({
+        "type": "draft_complete",
+        "draft_id": draft_id,
+        "event_name": event_name,
+        "raw_complete_draft": parsed.clone(),
+    })
+}
+
+/// Extracts the first JSON object or array from a multi-line log body.
+///
+/// The log header line may contain brackets (e.g., `[UnityCrossThreadLogger]`)
+/// that must not be confused with JSON array delimiters. This function
+/// determines a safe search start offset by skipping any `[...]` header
+/// prefix, then finds the first `{` or `[` from that offset.
+fn extract_json_from_body(body: &str) -> Option<&str> {
+    // If the body starts with a `[...]` header prefix, skip past it
+    // so we don't match the header bracket as a JSON array start.
+    let search_start = if body.starts_with('[') {
+        body.find(']').map_or(0, |pos| pos + 1)
+    } else {
+        0
+    };
+
+    let search_region = &body[search_start..];
+    let json_start = search_region.find(['{', '['])?;
+    let json_start = search_start + json_start;
+
+    let candidate = &body[json_start..];
+
+    let first_byte = candidate.as_bytes().first().copied()?;
+    let (open_char, close_char) = if first_byte == b'{' {
+        ('{', '}')
+    } else {
+        ('[', ']')
+    };
+
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut escape_next = false;
+    let mut end_pos = None;
+
+    for (i, ch) in candidate.char_indices() {
+        if escape_next {
+            escape_next = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => {
+                escape_next = true;
+            }
+            '"' => {
+                in_string = !in_string;
+            }
+            c if !in_string && c == open_char => {
+                depth += 1;
+            }
+            c if !in_string && c == close_char => {
+                depth -= 1;
+                if depth == 0 {
+                    end_pos = Some(i + 1);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    end_pos.map(|end| &candidate[..end])
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::PerformanceClass;
+    use crate::log::entry::EntryHeader;
+    use chrono::{TimeZone, Utc};
+
+    /// Helper: build a UTC timestamp for tests.
+    ///
+    /// Uses `unwrap_or_default()` because `clippy::expect_used` is denied
+    /// crate-wide. The epoch fallback would visibly fail timestamp assertions.
+    fn test_timestamp() -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 2, 25, 12, 0, 0)
+            .single()
+            .unwrap_or_default()
+    }
+
+    /// Helper: build a `LogEntry` with `UnityCrossThreadLogger` header.
+    fn unity_entry(body: &str) -> LogEntry {
+        LogEntry {
+            header: EntryHeader::UnityCrossThreadLogger,
+            body: body.to_owned(),
+        }
+    }
+
+    /// Helper: extract the JSON payload from a `GameEvent::DraftComplete` variant.
+    ///
+    /// Returns a static null value if the variant is not `DraftComplete`,
+    /// which will cause assertion failures that clearly indicate the wrong
+    /// variant was produced.
+    fn draft_complete_payload(event: &GameEvent) -> &serde_json::Value {
+        static EMPTY: std::sync::LazyLock<serde_json::Value> =
+            std::sync::LazyLock::new(|| serde_json::json!(null));
+        match event {
+            GameEvent::DraftComplete(e) => e.payload(),
+            _ => &EMPTY,
+        }
+    }
+
+    // -- Basic draft completion parsing --------------------------------------
+
+    mod basic_parsing {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_draft_complete_basic() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\n\
+                           \"DraftId\": \"abc-123-def\",\n\
+                           \"EventName\": \"PremierDraft_MKM_20260201\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["type"], "draft_complete");
+            assert_eq!(payload["draft_id"], "abc-123-def");
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_try_parse_draft_complete_traditional() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\n\
+                           \"DraftId\": \"trad-456\",\n\
+                           \"EventName\": \"TradDraft_DSK_20260115\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["draft_id"], "trad-456");
+            assert_eq!(payload["event_name"], "TradDraft_DSK_20260115");
+        }
+
+        #[test]
+        fn test_try_parse_draft_complete_quick_draft() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\n\
+                           \"DraftId\": \"quick-789\",\n\
+                           \"EventName\": \"QuickDraft_MKM_20260201\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["draft_id"], "quick-789");
+            assert_eq!(payload["event_name"], "QuickDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_try_parse_draft_complete_lowercase_draft_id() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\n\
+                           \"draftId\": \"lowercase-123\",\n\
+                           \"EventName\": \"PremierDraft_MKM_20260201\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["draft_id"], "lowercase-123");
+        }
+
+        #[test]
+        fn test_try_parse_draft_complete_internal_event_name() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\n\
+                           \"DraftId\": \"intern-456\",\n\
+                           \"InternalEventName\": \"PremierDraft_MKM_20260201\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+    }
+
+    // -- Missing / default fields --------------------------------------------
+
+    mod missing_fields {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_draft_complete_missing_draft_id() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\n\
+                           \"EventName\": \"PremierDraft_MKM_20260201\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["draft_id"], "");
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_try_parse_draft_complete_missing_event_name() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\n\
+                           \"DraftId\": \"no-event-name\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["draft_id"], "no-event-name");
+            assert_eq!(payload["event_name"], "");
+        }
+
+        #[test]
+        fn test_try_parse_draft_complete_minimal_payload() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["draft_id"], "");
+            assert_eq!(payload["event_name"], "");
+        }
+    }
+
+    // -- Metadata preservation -----------------------------------------------
+
+    mod metadata {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_draft_complete_preserves_raw_bytes() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\"DraftId\": \"raw-test\", \
+                          \"EventName\": \"PremierDraft_MKM_20260201\"}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
+        }
+
+        #[test]
+        fn test_try_parse_draft_complete_stores_timestamp() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\"DraftId\": \"ts-test\"}";
+            let entry = unity_entry(body);
+            let ts = test_timestamp();
+            let result = try_parse(&entry, ts);
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.metadata().timestamp(), ts);
+        }
+
+        #[test]
+        fn test_try_parse_draft_complete_preserves_raw_payload() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\n\
+                           \"DraftId\": \"raw-payload\",\n\
+                           \"ExtraField\": \"preserved\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["raw_complete_draft"]["ExtraField"], "preserved");
+        }
+    }
+
+    // -- Non-matching entries (should return None) ----------------------------
+
+    mod non_matching {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_unrelated_entry_returns_none() {
+            let body = "[UnityCrossThreadLogger]greToClientEvent\n{\"data\": 1}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_empty_body_returns_none() {
+            let body = "[UnityCrossThreadLogger]";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_bot_draft_entry_returns_none() {
+            let body = "[UnityCrossThreadLogger]BotDraft_DraftPick\n\
+                         {\"PickInfo\": {\"CardId\": 12345}}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_human_draft_entry_returns_none() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\"SelfPack\": 0, \"SelfPick\": 0, \
+                          \"PackCards\": \"12345\"}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_malformed_json_returns_none() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {broken json!!!}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_marker_only_no_json_returns_none() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_client_gre_header_returns_none() {
+            let entry = LogEntry {
+                header: EntryHeader::ClientGre,
+                body: "[Client GRE]some GRE message".to_owned(),
+            };
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+    }
+
+    // -- Header with timestamp -----------------------------------------------
+
+    mod timestamp_in_header {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_draft_complete_with_timestamp_prefix() {
+            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM \
+                         Draft_CompleteDraft\n\
+                         {\"DraftId\": \"ts-prefix\", \
+                          \"EventName\": \"PremierDraft_MKM_20260201\"}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["type"], "draft_complete");
+            assert_eq!(payload["draft_id"], "ts-prefix");
+        }
+    }
+
+    // -- Performance class ---------------------------------------------------
+
+    mod performance_class {
+        use super::*;
+
+        #[test]
+        fn test_draft_complete_event_is_durable_per_event() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\"DraftId\": \"perf-test\"}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.performance_class(), PerformanceClass::DurablePerEvent);
+        }
+    }
+
+    // -- Internal helpers ----------------------------------------------------
+
+    mod helpers {
+        use super::*;
+
+        #[test]
+        fn test_extract_json_from_body_object() {
+            let body = "header line\n{\"key\": \"value\"}";
+            let json = extract_json_from_body(body);
+            assert_eq!(json, Some("{\"key\": \"value\"}"));
+        }
+
+        #[test]
+        fn test_extract_json_from_body_no_json() {
+            assert!(extract_json_from_body("no json here").is_none());
+        }
+
+        #[test]
+        fn test_extract_json_from_body_with_header_bracket() {
+            let body = "[UnityCrossThreadLogger]some text\n{\"data\": 1}";
+            let json = extract_json_from_body(body);
+            assert_eq!(json, Some("{\"data\": 1}"));
+        }
+
+        #[test]
+        fn test_build_payload_full() {
+            let parsed = serde_json::json!({
+                "DraftId": "test-id",
+                "EventName": "PremierDraft_MKM_20260201"
+            });
+            let payload = build_payload(&parsed);
+            assert_eq!(payload["type"], "draft_complete");
+            assert_eq!(payload["draft_id"], "test-id");
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_build_payload_empty() {
+            let parsed = serde_json::json!({});
+            let payload = build_payload(&parsed);
+            assert_eq!(payload["draft_id"], "");
+            assert_eq!(payload["event_name"], "");
+        }
+    }
+}

--- a/src/parsers/draft/human.rs
+++ b/src/parsers/draft/human.rs
@@ -1,0 +1,1283 @@
+//! Human draft parser for Premier Draft and Traditional Draft events.
+//!
+//! In human (pod) drafts, the player drafts against other human players.
+//! Three log signatures capture the draft flow:
+//!
+//! | Signature | Meaning | Key Fields |
+//! |-----------|---------|------------|
+//! | `Draft.Notify` | Draft state notification (pack presented) | `draftId`, `SelfPack`, `SelfPick`, `PackCards` |
+//! | `EventPlayerDraftMakePick` | Player's pick selection | `EventName`, `PickInfo` with `CardId`, `PackNumber`, `PickNumber` |
+//! | `LogBusinessEvents` with `PickGrpId` | Pick confirmation (business event) | `PickGrpId`, `PackCards`, `EventName` |
+//!
+//! Human drafts have 3 packs of 14 picks each (42 total picks). Pack and
+//! pick numbers are zero-indexed in the log.
+//!
+//! All three events are Class 2 (Durable Per-Event) -- each pick is
+//! independently valuable and must survive crashes.
+
+use crate::events::{DraftHumanEvent, EventMetadata, GameEvent};
+use crate::log::entry::LogEntry;
+
+/// Marker for human draft state notification events.
+///
+/// `Draft.Notify` appears in the log when a new pack is presented to the
+/// player during a Premier or Traditional Draft.
+const DRAFT_NOTIFY_MARKER: &str = "Draft.Notify";
+
+/// Marker for human draft pick selection events.
+///
+/// `EventPlayerDraftMakePick` appears after the player selects a card
+/// from the presented pack.
+const MAKE_PICK_MARKER: &str = "EventPlayerDraftMakePick";
+
+/// Marker that identifies business event entries in the log.
+///
+/// `LogBusinessEvents` is a shared container used for multiple event types
+/// (game results, draft picks, etc.). We further discriminate by checking
+/// for the `PickGrpId` field.
+const BUSINESS_EVENTS_MARKER: &str = "LogBusinessEvents";
+
+/// Field that distinguishes draft pick business events from other
+/// `LogBusinessEvents` entries (e.g., game results with `WinningType`).
+const PICK_GRP_ID_FIELD: &str = "PickGrpId";
+
+/// Attempts to parse a [`LogEntry`] as a human draft event.
+///
+/// Returns `Some(GameEvent::DraftHuman(_))` if the entry matches any of:
+/// - A `Draft.Notify` pack presentation
+/// - An `EventPlayerDraftMakePick` pick selection
+/// - A `LogBusinessEvents` with `PickGrpId` pick confirmation
+///
+/// Returns `None` if the entry does not match any human draft signature.
+///
+/// The `timestamp` is used to construct [`EventMetadata`] for the resulting
+/// event. Callers are responsible for parsing the timestamp from the log
+/// entry header before invoking this function.
+pub fn try_parse(entry: &LogEntry, timestamp: chrono::DateTime<chrono::Utc>) -> Option<GameEvent> {
+    let body = &entry.body;
+
+    // Try Draft.Notify first (pack presentation -- most common during drafting).
+    if let Some(payload) = try_parse_draft_notify(body) {
+        let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
+        return Some(GameEvent::DraftHuman(DraftHumanEvent::new(
+            metadata, payload,
+        )));
+    }
+
+    // Try EventPlayerDraftMakePick (pick selection).
+    if let Some(payload) = try_parse_make_pick(body) {
+        let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
+        return Some(GameEvent::DraftHuman(DraftHumanEvent::new(
+            metadata, payload,
+        )));
+    }
+
+    // Try LogBusinessEvents with PickGrpId (pick confirmation).
+    if let Some(payload) = try_parse_pick_business_event(body) {
+        let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
+        return Some(GameEvent::DraftHuman(DraftHumanEvent::new(
+            metadata, payload,
+        )));
+    }
+
+    None
+}
+
+/// Attempts to parse a `Draft.Notify` pack presentation event.
+///
+/// The log entry body contains a JSON object with:
+/// - `draftId`: unique identifier for this draft session
+/// - `SelfPack`: zero-indexed pack number (0, 1, 2)
+/// - `SelfPick`: zero-indexed pick number within the pack
+/// - `PackCards`: comma-separated string of card GRP IDs in the pack
+fn try_parse_draft_notify(body: &str) -> Option<serde_json::Value> {
+    if !body.contains(DRAFT_NOTIFY_MARKER) {
+        return None;
+    }
+
+    let json_str = extract_json_from_body(body)?;
+
+    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            ::log::warn!("Draft.Notify: malformed JSON payload: {e}");
+            return None;
+        }
+    };
+
+    // Verify this is a Draft.Notify by checking for characteristic fields.
+    // PackCards is the hallmark of a Draft.Notify payload.
+    if parsed.get("PackCards").is_none() && parsed.get("SelfPack").is_none() {
+        return None;
+    }
+
+    let draft_id = parsed
+        .get("draftId")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    let pack_idx = parsed
+        .get("SelfPack")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+
+    let selection_idx = parsed
+        .get("SelfPick")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+
+    let pack_cards = extract_pack_cards_from_string(&parsed);
+
+    Some(serde_json::json!({
+        "type": "draft_human_notify",
+        "draft_id": draft_id,
+        "pack_number": pack_idx,
+        "pick_number": selection_idx,
+        "pack_cards": pack_cards,
+        "raw_draft_notify": parsed,
+    }))
+}
+
+/// Attempts to parse an `EventPlayerDraftMakePick` pick selection event.
+///
+/// The log entry body contains a JSON object with:
+/// - `EventName`: the Arena event identifier
+/// - `PickInfo` (optional wrapper) containing:
+///   - `CardId`: the GRP ID of the selected card
+///   - `PackNumber`: zero-indexed pack number
+///   - `PickNumber`: zero-indexed pick number within the pack
+fn try_parse_make_pick(body: &str) -> Option<serde_json::Value> {
+    if !body.contains(MAKE_PICK_MARKER) {
+        return None;
+    }
+
+    let json_str = extract_json_from_body(body)?;
+
+    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            ::log::warn!("EventPlayerDraftMakePick: malformed JSON payload: {e}");
+            return None;
+        }
+    };
+
+    // The pick info may be at top level or nested under a `PickInfo` key.
+    let pick_info = parsed.get("PickInfo").unwrap_or(&parsed);
+
+    let card_id = pick_info
+        .get("CardId")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+
+    let pack_idx = pick_info
+        .get("PackNumber")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+
+    let selection_idx = pick_info
+        .get("PickNumber")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+
+    let event_name = parsed
+        .get("EventName")
+        .or_else(|| pick_info.get("EventName"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    // Some entries include the full list of card IDs that were in the pack.
+    let card_ids = pick_info
+        .get("CardIds")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(serde_json::Value::as_i64)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Some(serde_json::json!({
+        "type": "draft_human_pick",
+        "event_name": event_name,
+        "card_id": card_id,
+        "pack_number": pack_idx,
+        "pick_number": selection_idx,
+        "card_ids": card_ids,
+        "raw_make_pick": parsed,
+    }))
+}
+
+/// Attempts to parse a `LogBusinessEvents` with `PickGrpId` pick confirmation.
+///
+/// The log entry body contains a JSON object (or array of objects) with:
+/// - `PickGrpId`: the GRP ID of the picked card
+/// - `PackCards`: card GRP IDs that were in the pack (may be comma-separated
+///   string or array)
+/// - `EventName` or `InternalEventName`: the Arena event identifier
+fn try_parse_pick_business_event(body: &str) -> Option<serde_json::Value> {
+    // Must contain both the business events marker and PickGrpId.
+    if !body.contains(BUSINESS_EVENTS_MARKER) {
+        return None;
+    }
+
+    if !body.contains(PICK_GRP_ID_FIELD) {
+        return None;
+    }
+
+    let json_str = extract_json_from_body(body)?;
+
+    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            ::log::warn!("LogBusinessEvents (draft pick): malformed JSON payload: {e}");
+            return None;
+        }
+    };
+
+    // Find the source object containing PickGrpId.
+    let source = find_pick_source(&parsed)?;
+
+    let pick_grp_id = source
+        .get("PickGrpId")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+
+    let pack_cards = extract_business_event_pack_cards(source);
+
+    let event_name = source
+        .get("EventName")
+        .or_else(|| source.get("InternalEventName"))
+        .or_else(|| parsed.get("EventName"))
+        .or_else(|| parsed.get("InternalEventName"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    let pack_idx = source
+        .get("PackNumber")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+
+    let selection_idx = source
+        .get("PickNumber")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0);
+
+    Some(serde_json::json!({
+        "type": "draft_human_pick_confirm",
+        "pick_grp_id": pick_grp_id,
+        "pack_cards": pack_cards,
+        "event_name": event_name,
+        "pack_number": pack_idx,
+        "pick_number": selection_idx,
+        "raw_business_event": parsed,
+    }))
+}
+
+/// Finds the source object containing `PickGrpId` within a parsed JSON value.
+///
+/// Searches the top level, inside a `Params` object, and inside a
+/// top-level array of business events.
+fn find_pick_source(parsed: &serde_json::Value) -> Option<&serde_json::Value> {
+    // Top level.
+    if parsed.get(PICK_GRP_ID_FIELD).is_some() {
+        return Some(parsed);
+    }
+
+    // Inside a `Params` object.
+    if let Some(params) = parsed.get("Params") {
+        if params.get(PICK_GRP_ID_FIELD).is_some() {
+            return Some(params);
+        }
+    }
+
+    // Inside a top-level array of business events.
+    if let Some(arr) = parsed.as_array() {
+        return arr
+            .iter()
+            .find(|item| item.get(PICK_GRP_ID_FIELD).is_some());
+    }
+
+    None
+}
+
+/// Extracts pack card IDs from a `PackCards` field in a business event.
+///
+/// `PackCards` may be a comma-separated string of GRP IDs (e.g., `"12345,67890"`)
+/// or an array of integers. This function normalizes to `Vec<i64>`.
+fn extract_business_event_pack_cards(source: &serde_json::Value) -> Vec<i64> {
+    if let Some(pack_cards) = source.get("PackCards") {
+        // Try as comma-separated string first.
+        if let Some(s) = pack_cards.as_str() {
+            return parse_comma_separated_ids(s);
+        }
+
+        // Try as array.
+        if let Some(arr) = pack_cards.as_array() {
+            return arr
+                .iter()
+                .filter_map(|v| {
+                    v.as_i64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+                })
+                .collect();
+        }
+    }
+
+    Vec::new()
+}
+
+/// Extracts pack card IDs from a `PackCards` field in a `Draft.Notify` payload.
+///
+/// In `Draft.Notify`, `PackCards` is typically a comma-separated string of
+/// GRP IDs (e.g., `"12345,67890,11111"`). This function also handles
+/// array format for robustness.
+fn extract_pack_cards_from_string(parsed: &serde_json::Value) -> Vec<i64> {
+    if let Some(pack_cards) = parsed.get("PackCards") {
+        // Comma-separated string (most common format in Draft.Notify).
+        if let Some(s) = pack_cards.as_str() {
+            return parse_comma_separated_ids(s);
+        }
+
+        // Array format (less common but possible).
+        if let Some(arr) = pack_cards.as_array() {
+            return arr
+                .iter()
+                .filter_map(|v| {
+                    v.as_i64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+                })
+                .collect();
+        }
+    }
+
+    Vec::new()
+}
+
+/// Parses a comma-separated string of integer IDs into a `Vec<i64>`.
+///
+/// Silently skips any non-numeric segments.
+fn parse_comma_separated_ids(s: &str) -> Vec<i64> {
+    s.split(',')
+        .filter_map(|segment| segment.trim().parse::<i64>().ok())
+        .collect()
+}
+
+/// Extracts the first JSON object or array from a multi-line log body.
+///
+/// The log header line may contain brackets (e.g., `[UnityCrossThreadLogger]`)
+/// that must not be confused with JSON array delimiters. This function
+/// determines a safe search start offset by skipping any `[...]` header
+/// prefix, then finds the first `{` or `[` from that offset.
+fn extract_json_from_body(body: &str) -> Option<&str> {
+    // If the body starts with a `[...]` header prefix, skip past it
+    // so we don't match the header bracket as a JSON array start.
+    let search_start = if body.starts_with('[') {
+        body.find(']').map_or(0, |pos| pos + 1)
+    } else {
+        0
+    };
+
+    let search_region = &body[search_start..];
+    let json_start = search_region.find(['{', '['])?;
+    let json_start = search_start + json_start;
+
+    let candidate = &body[json_start..];
+
+    let first_byte = candidate.as_bytes().first().copied()?;
+    let (open_char, close_char) = if first_byte == b'{' {
+        ('{', '}')
+    } else {
+        ('[', ']')
+    };
+
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut escape_next = false;
+    let mut end_pos = None;
+
+    for (i, ch) in candidate.char_indices() {
+        if escape_next {
+            escape_next = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => {
+                escape_next = true;
+            }
+            '"' => {
+                in_string = !in_string;
+            }
+            c if !in_string && c == open_char => {
+                depth += 1;
+            }
+            c if !in_string && c == close_char => {
+                depth -= 1;
+                if depth == 0 {
+                    end_pos = Some(i + 1);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    end_pos.map(|end| &candidate[..end])
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::PerformanceClass;
+    use crate::log::entry::EntryHeader;
+    use chrono::{TimeZone, Utc};
+
+    /// Helper: build a UTC timestamp for tests.
+    ///
+    /// Uses `unwrap_or_default()` because `clippy::expect_used` is denied
+    /// crate-wide. The epoch fallback would visibly fail timestamp assertions.
+    fn test_timestamp() -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 2, 25, 12, 0, 0)
+            .single()
+            .unwrap_or_default()
+    }
+
+    /// Helper: build a `LogEntry` with `UnityCrossThreadLogger` header.
+    fn unity_entry(body: &str) -> LogEntry {
+        LogEntry {
+            header: EntryHeader::UnityCrossThreadLogger,
+            body: body.to_owned(),
+        }
+    }
+
+    /// Helper: extract the JSON payload from a `GameEvent::DraftHuman` variant.
+    ///
+    /// Returns a static null value if the variant is not `DraftHuman`,
+    /// which will cause assertion failures that clearly indicate the wrong
+    /// variant was produced.
+    fn draft_human_payload(event: &GameEvent) -> &serde_json::Value {
+        static EMPTY: std::sync::LazyLock<serde_json::Value> =
+            std::sync::LazyLock::new(|| serde_json::json!(null));
+        match event {
+            GameEvent::DraftHuman(e) => e.payload(),
+            _ => &EMPTY,
+        }
+    }
+
+    // -- Draft.Notify parsing ------------------------------------------------
+
+    mod draft_notify {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_draft_notify_basic() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\n\
+                           \"draftId\": \"abc-123-def\",\n\
+                           \"SelfPack\": 0,\n\
+                           \"SelfPick\": 0,\n\
+                           \"PackCards\": \"12345,67890,11111\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["type"], "draft_human_notify");
+            assert_eq!(payload["draft_id"], "abc-123-def");
+            assert_eq!(payload["pack_number"], 0);
+            assert_eq!(payload["pick_number"], 0);
+            assert_eq!(
+                payload["pack_cards"],
+                serde_json::json!([12345, 67890, 11111])
+            );
+        }
+
+        #[test]
+        fn test_try_parse_draft_notify_second_pack() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\n\
+                           \"draftId\": \"draft-456\",\n\
+                           \"SelfPack\": 1,\n\
+                           \"SelfPick\": 5,\n\
+                           \"PackCards\": \"22222,33333,44444,55555\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["pack_number"], 1);
+            assert_eq!(payload["pick_number"], 5);
+            assert_eq!(payload["draft_id"], "draft-456");
+            assert_eq!(
+                payload["pack_cards"],
+                serde_json::json!([22222, 33333, 44444, 55555])
+            );
+        }
+
+        #[test]
+        fn test_try_parse_draft_notify_last_pick_single_card() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\n\
+                           \"draftId\": \"draft-789\",\n\
+                           \"SelfPack\": 2,\n\
+                           \"SelfPick\": 13,\n\
+                           \"PackCards\": \"99999\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["pack_number"], 2);
+            assert_eq!(payload["pick_number"], 13);
+            assert_eq!(payload["pack_cards"], serde_json::json!([99999]));
+        }
+
+        #[test]
+        fn test_try_parse_draft_notify_empty_pack_cards() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\n\
+                           \"draftId\": \"draft-empty\",\n\
+                           \"SelfPack\": 0,\n\
+                           \"SelfPick\": 0,\n\
+                           \"PackCards\": \"\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["pack_cards"], serde_json::json!([]));
+        }
+
+        #[test]
+        fn test_try_parse_draft_notify_array_format_pack_cards() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\n\
+                           \"draftId\": \"draft-arr\",\n\
+                           \"SelfPack\": 0,\n\
+                           \"SelfPick\": 0,\n\
+                           \"PackCards\": [12345, 67890]\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["pack_cards"], serde_json::json!([12345, 67890]));
+        }
+
+        #[test]
+        fn test_try_parse_draft_notify_missing_draft_id() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\n\
+                           \"SelfPack\": 0,\n\
+                           \"SelfPick\": 0,\n\
+                           \"PackCards\": \"12345\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["draft_id"], "");
+        }
+
+        #[test]
+        fn test_try_parse_draft_notify_preserves_raw_payload() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\n\
+                           \"draftId\": \"draft-raw\",\n\
+                           \"SelfPack\": 0,\n\
+                           \"SelfPick\": 0,\n\
+                           \"PackCards\": \"12345\",\n\
+                           \"ExtraField\": \"preserved\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["raw_draft_notify"]["ExtraField"], "preserved");
+        }
+
+        #[test]
+        fn test_try_parse_draft_notify_with_timestamp_in_header() {
+            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM \
+                         Draft.Notify\n\
+                         {\n\
+                           \"draftId\": \"draft-ts\",\n\
+                           \"SelfPack\": 0,\n\
+                           \"SelfPick\": 0,\n\
+                           \"PackCards\": \"12345\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["type"], "draft_human_notify");
+        }
+    }
+
+    // -- EventPlayerDraftMakePick parsing ------------------------------------
+
+    mod make_pick {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_make_pick_basic() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\n\
+                           \"EventName\": \"PremierDraft_MKM_20260201\",\n\
+                           \"PickInfo\": {\n\
+                             \"CardId\": 12345,\n\
+                             \"PackNumber\": 0,\n\
+                             \"PickNumber\": 0\n\
+                           }\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["type"], "draft_human_pick");
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+            assert_eq!(payload["card_id"], 12345);
+            assert_eq!(payload["pack_number"], 0);
+            assert_eq!(payload["pick_number"], 0);
+        }
+
+        #[test]
+        fn test_try_parse_make_pick_later_in_draft() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\n\
+                           \"EventName\": \"TradDraft_DSK_20260115\",\n\
+                           \"PickInfo\": {\n\
+                             \"CardId\": 67890,\n\
+                             \"PackNumber\": 1,\n\
+                             \"PickNumber\": 7\n\
+                           }\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["card_id"], 67890);
+            assert_eq!(payload["pack_number"], 1);
+            assert_eq!(payload["pick_number"], 7);
+            assert_eq!(payload["event_name"], "TradDraft_DSK_20260115");
+        }
+
+        #[test]
+        fn test_try_parse_make_pick_with_card_ids() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\n\
+                           \"EventName\": \"PremierDraft_MKM_20260201\",\n\
+                           \"PickInfo\": {\n\
+                             \"CardId\": 11111,\n\
+                             \"PackNumber\": 0,\n\
+                             \"PickNumber\": 0,\n\
+                             \"CardIds\": [11111, 22222, 33333]\n\
+                           }\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["card_id"], 11111);
+            assert_eq!(
+                payload["card_ids"],
+                serde_json::json!([11111, 22222, 33333])
+            );
+        }
+
+        #[test]
+        fn test_try_parse_make_pick_flat_format() {
+            // Some log versions put fields at the top level instead of
+            // nesting under PickInfo.
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\n\
+                           \"CardId\": 55555,\n\
+                           \"PackNumber\": 2,\n\
+                           \"PickNumber\": 10\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["card_id"], 55555);
+            assert_eq!(payload["pack_number"], 2);
+            assert_eq!(payload["pick_number"], 10);
+        }
+
+        #[test]
+        fn test_try_parse_make_pick_missing_card_id_defaults_to_zero() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\n\
+                           \"PickInfo\": {\n\
+                             \"PackNumber\": 0,\n\
+                             \"PickNumber\": 0\n\
+                           }\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["card_id"], 0);
+        }
+
+        #[test]
+        fn test_try_parse_make_pick_preserves_raw_payload() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\n\
+                           \"PickInfo\": {\n\
+                             \"CardId\": 12345,\n\
+                             \"PackNumber\": 0,\n\
+                             \"PickNumber\": 0,\n\
+                             \"ExtraField\": \"kept\"\n\
+                           }\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["raw_make_pick"]["PickInfo"]["ExtraField"], "kept");
+        }
+
+        #[test]
+        fn test_try_parse_make_pick_with_timestamp_in_header() {
+            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM \
+                         EventPlayerDraftMakePick\n\
+                         {\n\
+                           \"PickInfo\": {\n\
+                             \"CardId\": 77777,\n\
+                             \"PackNumber\": 0,\n\
+                             \"PickNumber\": 1\n\
+                           }\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["card_id"], 77777);
+        }
+    }
+
+    // -- LogBusinessEvents with PickGrpId parsing ----------------------------
+
+    mod pick_business_event {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_pick_business_event_basic() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\n\
+                           \"PickGrpId\": 12345,\n\
+                           \"PackCards\": \"12345,67890,11111\",\n\
+                           \"EventName\": \"PremierDraft_MKM_20260201\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["type"], "draft_human_pick_confirm");
+            assert_eq!(payload["pick_grp_id"], 12345);
+            assert_eq!(
+                payload["pack_cards"],
+                serde_json::json!([12345, 67890, 11111])
+            );
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_try_parse_pick_business_event_with_pack_pick_numbers() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\n\
+                           \"PickGrpId\": 67890,\n\
+                           \"PackNumber\": 1,\n\
+                           \"PickNumber\": 5,\n\
+                           \"PackCards\": \"67890,22222\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["pick_grp_id"], 67890);
+            assert_eq!(payload["pack_number"], 1);
+            assert_eq!(payload["pick_number"], 5);
+        }
+
+        #[test]
+        fn test_try_parse_pick_business_event_params_wrapper() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\n\
+                           \"Params\": {\n\
+                             \"PickGrpId\": 33333,\n\
+                             \"PackCards\": \"33333,44444,55555\"\n\
+                           }\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["pick_grp_id"], 33333);
+            assert_eq!(
+                payload["pack_cards"],
+                serde_json::json!([33333, 44444, 55555])
+            );
+        }
+
+        #[test]
+        fn test_try_parse_pick_business_event_array_format() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         [\n\
+                           {\"SomeOtherField\": \"value\"},\n\
+                           {\n\
+                             \"PickGrpId\": 44444,\n\
+                             \"PackCards\": \"44444,55555\"\n\
+                           }\n\
+                         ]";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["pick_grp_id"], 44444);
+        }
+
+        #[test]
+        fn test_try_parse_pick_business_event_array_pack_cards() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\n\
+                           \"PickGrpId\": 12345,\n\
+                           \"PackCards\": [12345, 67890, 11111]\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(
+                payload["pack_cards"],
+                serde_json::json!([12345, 67890, 11111])
+            );
+        }
+
+        #[test]
+        fn test_try_parse_pick_business_event_preserves_raw_payload() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\n\
+                           \"PickGrpId\": 12345,\n\
+                           \"ExtraField\": \"preserved\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["raw_business_event"]["ExtraField"], "preserved");
+        }
+
+        #[test]
+        fn test_try_parse_pick_business_event_with_timestamp_in_header() {
+            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM \
+                         LogBusinessEvents\n\
+                         {\n\
+                           \"PickGrpId\": 88888,\n\
+                           \"PackCards\": \"88888\"\n\
+                         }";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_human_payload(event);
+
+            assert_eq!(payload["pick_grp_id"], 88888);
+        }
+    }
+
+    // -- Metadata preservation -----------------------------------------------
+
+    mod metadata {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_preserves_raw_bytes_notify() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\"SelfPack\": 0, \"SelfPick\": 0, \
+                          \"PackCards\": \"12345\"}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
+        }
+
+        #[test]
+        fn test_try_parse_preserves_raw_bytes_make_pick() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\"PickInfo\": {\"CardId\": 1, \"PackNumber\": 0, \
+                          \"PickNumber\": 0}}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
+        }
+
+        #[test]
+        fn test_try_parse_preserves_raw_bytes_business_event() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\"PickGrpId\": 12345}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
+        }
+
+        #[test]
+        fn test_try_parse_stores_timestamp_notify() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\"SelfPack\": 0, \"SelfPick\": 0, \
+                          \"PackCards\": \"12345\"}";
+            let entry = unity_entry(body);
+            let ts = test_timestamp();
+            let result = try_parse(&entry, ts);
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.metadata().timestamp(), ts);
+        }
+
+        #[test]
+        fn test_try_parse_stores_timestamp_make_pick() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\"PickInfo\": {\"CardId\": 1, \"PackNumber\": 0, \
+                          \"PickNumber\": 0}}";
+            let entry = unity_entry(body);
+            let ts = test_timestamp();
+            let result = try_parse(&entry, ts);
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.metadata().timestamp(), ts);
+        }
+
+        #[test]
+        fn test_try_parse_stores_timestamp_business_event() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\"PickGrpId\": 12345}";
+            let entry = unity_entry(body);
+            let ts = test_timestamp();
+            let result = try_parse(&entry, ts);
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.metadata().timestamp(), ts);
+        }
+    }
+
+    // -- Non-matching entries (should return None) ----------------------------
+
+    mod non_matching {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_unrelated_entry_returns_none() {
+            let body = "[UnityCrossThreadLogger]greToClientEvent\n{\"data\": 1}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_empty_body_returns_none() {
+            let body = "[UnityCrossThreadLogger]";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_bot_draft_entry_returns_none() {
+            // Bot draft entries should not be parsed by the human draft parser.
+            let body = "[UnityCrossThreadLogger]BotDraft_DraftPick\n\
+                         {\n\
+                           \"PickInfo\": {\n\
+                             \"CardId\": 12345,\n\
+                             \"PackNumber\": 0,\n\
+                             \"PickNumber\": 0\n\
+                           }\n\
+                         }";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_game_result_business_event_returns_none() {
+            // Game result LogBusinessEvents (with WinningType) should not
+            // match the human draft parser.
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\n\
+                           \"WinningType\": \"WinLoss\",\n\
+                           \"WinningTeamId\": 1\n\
+                         }";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_malformed_json_notify_returns_none() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\"PackCards\": broken!!!}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_malformed_json_make_pick_returns_none() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {not valid json}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_malformed_json_business_event_returns_none() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\"PickGrpId\": broken!!!}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_marker_only_no_json_notify_returns_none() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_marker_only_no_json_make_pick_returns_none() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_draft_notify_no_pack_or_self_pack_returns_none() {
+            // Draft.Notify marker in text but JSON has no characteristic fields.
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\"unrelatedField\": \"value\"}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_client_gre_header_returns_none() {
+            let entry = LogEntry {
+                header: EntryHeader::ClientGre,
+                body: "[Client GRE]some GRE message".to_owned(),
+            };
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
+    }
+
+    // -- Performance class ---------------------------------------------------
+
+    mod performance_class {
+        use super::*;
+
+        #[test]
+        fn test_draft_human_notify_is_durable_per_event() {
+            let body = "[UnityCrossThreadLogger]Draft.Notify\n\
+                         {\"SelfPack\": 0, \"SelfPick\": 0, \
+                          \"PackCards\": \"12345\"}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.performance_class(), PerformanceClass::DurablePerEvent);
+        }
+
+        #[test]
+        fn test_draft_human_pick_is_durable_per_event() {
+            let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
+                         {\"PickInfo\": {\"CardId\": 1, \"PackNumber\": 0, \
+                          \"PickNumber\": 0}}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.performance_class(), PerformanceClass::DurablePerEvent);
+        }
+
+        #[test]
+        fn test_draft_human_business_event_is_durable_per_event() {
+            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
+                         {\"PickGrpId\": 12345}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert_eq!(event.performance_class(), PerformanceClass::DurablePerEvent);
+        }
+    }
+
+    // -- Internal helpers ----------------------------------------------------
+
+    mod helpers {
+        use super::*;
+
+        #[test]
+        fn test_extract_json_from_body_object() {
+            let body = "header line\n{\"key\": \"value\"}";
+            let json = extract_json_from_body(body);
+            assert_eq!(json, Some("{\"key\": \"value\"}"));
+        }
+
+        #[test]
+        fn test_extract_json_from_body_array() {
+            let body = "header line\n[{\"key\": \"value\"}]";
+            let json = extract_json_from_body(body);
+            assert_eq!(json, Some("[{\"key\": \"value\"}]"));
+        }
+
+        #[test]
+        fn test_extract_json_from_body_no_json() {
+            assert!(extract_json_from_body("no json here").is_none());
+        }
+
+        #[test]
+        fn test_extract_json_from_body_with_header_bracket() {
+            let body = "[UnityCrossThreadLogger]some text\n{\"data\": 1}";
+            let json = extract_json_from_body(body);
+            assert_eq!(json, Some("{\"data\": 1}"));
+        }
+
+        #[test]
+        fn test_parse_comma_separated_ids_basic() {
+            assert_eq!(
+                parse_comma_separated_ids("12345,67890,11111"),
+                vec![12345, 67890, 11111]
+            );
+        }
+
+        #[test]
+        fn test_parse_comma_separated_ids_with_spaces() {
+            assert_eq!(
+                parse_comma_separated_ids("12345, 67890, 11111"),
+                vec![12345, 67890, 11111]
+            );
+        }
+
+        #[test]
+        fn test_parse_comma_separated_ids_single() {
+            assert_eq!(parse_comma_separated_ids("12345"), vec![12345]);
+        }
+
+        #[test]
+        fn test_parse_comma_separated_ids_empty() {
+            let result: Vec<i64> = parse_comma_separated_ids("");
+            assert!(result.is_empty());
+        }
+
+        #[test]
+        fn test_parse_comma_separated_ids_with_invalid() {
+            assert_eq!(
+                parse_comma_separated_ids("12345,abc,67890"),
+                vec![12345, 67890]
+            );
+        }
+
+        #[test]
+        fn test_find_pick_source_top_level() {
+            let val = serde_json::json!({"PickGrpId": 12345});
+            assert!(find_pick_source(&val).is_some());
+        }
+
+        #[test]
+        fn test_find_pick_source_in_params() {
+            let val = serde_json::json!({"Params": {"PickGrpId": 12345}});
+            assert!(find_pick_source(&val).is_some());
+        }
+
+        #[test]
+        fn test_find_pick_source_in_array() {
+            let val = serde_json::json!([
+                {"SomeField": 1},
+                {"PickGrpId": 12345}
+            ]);
+            assert!(find_pick_source(&val).is_some());
+        }
+
+        #[test]
+        fn test_find_pick_source_absent() {
+            let val = serde_json::json!({"WinningType": "WinLoss"});
+            assert!(find_pick_source(&val).is_none());
+        }
+    }
+}

--- a/src/parsers/draft/mod.rs
+++ b/src/parsers/draft/mod.rs
@@ -5,5 +5,9 @@
 //! | Module | Log Signatures | Event Type |
 //! |--------|---------------|------------|
 //! | [`bot`] | `DraftStatus: "PickNext"`, `BotDraft_DraftPick` | [`DraftBotEvent`](crate::events::DraftBotEvent) |
+//! | [`human`] | `Draft.Notify`, `EventPlayerDraftMakePick`, `LogBusinessEvents` with `PickGrpId` | [`DraftHumanEvent`](crate::events::DraftHumanEvent) |
+//! | [`complete`] | `Draft_CompleteDraft` | [`DraftCompleteEvent`](crate::events::DraftCompleteEvent) |
 
 pub mod bot;
+pub mod complete;
+pub mod human;


### PR DESCRIPTION
## Summary
- Add human draft parser (`Draft.Notify`, `EventPlayerDraftMakePick`, `LogBusinessEvents` with `PickGrpId`)
- Add draft completion parser (`Draft_CompleteDraft`)
- Both emit Class 2 (Durable Per-Event) events for crash resilience

## Changes Made
- `src/parsers/draft/human.rs` — New parser for three human draft log signatures:
  - `Draft.Notify`: Pack presentation with comma-separated `PackCards` and `SelfPack`/`SelfPick` indices
  - `EventPlayerDraftMakePick`: Player's card selection with `PickInfo` (supports nested and flat formats)
  - `LogBusinessEvents` with `PickGrpId`: Pick confirmation business event (disambiguated from game results by `PickGrpId` vs `WinningType`)
- `src/parsers/draft/complete.rs` — New parser for `Draft_CompleteDraft` events, extracting `DraftId` and `EventName`
- `src/parsers/draft/mod.rs` — Expose new `human` and `complete` sub-modules with doc table

## Testing
- 585 tests passing (0 failures)
- ~80 new tests covering: all three human draft signatures, draft completion, metadata/timestamp preservation, raw payload preservation, non-matching entries, performance class verification, and internal helpers (JSON extraction, comma-separated ID parsing, `PickGrpId` source finding)
- Clippy clean (`-D warnings`), formatted

## Stacked PR
Base: `issue/146-bot-draft-parser` — merge in order after earlier PRs.

Fixes manasight/manasight-docs#147

🤖 Generated with [Claude Code](https://claude.com/claude-code)