### PR TITLE
Fix manasight/manasight-docs#164: Real-log smoke test harness

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -23,16 +23,23 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Resolve log source URL
+      - name: Resolve log source
         id: resolve-url
+        env:
+          INPUT_LOGS_URL: ${{ inputs.logs_url }}
+          SECRET_LOGS_URL: ${{ secrets.MANASIGHT_TEST_LOGS_URL }}
         run: |
-          URL="${{ inputs.logs_url || secrets.MANASIGHT_TEST_LOGS_URL }}"
+          # Determine which URL to use (input takes precedence over secret).
+          # Compute a stable cache key from the URL so that a new URL gets a
+          # fresh cache rather than reusing a hit from a previous URL.
+          URL="${INPUT_LOGS_URL:-$SECRET_LOGS_URL}"
           if [ -z "$URL" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No log source configured — skipping smoke test"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "url=$URL" >> "$GITHUB_OUTPUT"
+            URL_HASH="$(echo -n "$URL" | sha256sum | cut -c1-16)"
+            echo "cache_key=smoke-test-logs-v1-${URL_HASH}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Cache test logs
@@ -41,13 +48,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/test-logs
-          key: smoke-test-logs-v1
+          key: ${{ steps.resolve-url.outputs.cache_key }}
 
       - name: Download test logs
         if: steps.resolve-url.outputs.skip == 'false' && steps.cache-logs.outputs.cache-hit != 'true'
+        env:
+          LOGS_URL: ${{ inputs.logs_url || secrets.MANASIGHT_TEST_LOGS_URL }}
         run: |
           mkdir -p /tmp/test-logs
-          curl -fsSL "${{ steps.resolve-url.outputs.url }}" | tar -xz -C /tmp/test-logs
+          curl -fsSL "$LOGS_URL" | tar -xz -C /tmp/test-logs
           echo "Downloaded logs:"
           ls -lh /tmp/test-logs/
 

--- a/tests/smoke_real_logs.rs
+++ b/tests/smoke_real_logs.rs
@@ -52,6 +52,8 @@ struct ParserStats {
 /// Aggregated report for a single log file.
 struct FileReport {
     filename: String,
+    /// Set when the file could not be read; remaining fields are zeroed.
+    read_error: bool,
     total_entries: usize,
     parser_stats: Vec<(&'static str, ParserStats)>,
     unclaimed: usize,
@@ -149,11 +151,25 @@ fn try_extract_timestamp(body: &str) -> Option<DateTime<Utc>> {
 
 /// Processes a single log file through all parsers and returns a report.
 fn process_file(path: &Path, parsers: &[NamedParser]) -> FileReport {
-    let content = std::fs::read_to_string(path).unwrap_or_default();
     let filename = path
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default();
+
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return FileReport {
+            filename,
+            read_error: true,
+            total_entries: 0,
+            parser_stats: parsers
+                .iter()
+                .map(|p| (p.name, ParserStats::default()))
+                .collect(),
+            unclaimed: 0,
+            double_claims: 0,
+            timestamp_failures: 0,
+        };
+    };
 
     // Split content into entries via LineBuffer.
     let mut buffer = LineBuffer::new();
@@ -214,6 +230,7 @@ fn process_file(path: &Path, parsers: &[NamedParser]) -> FileReport {
 
     FileReport {
         filename,
+        read_error: false,
         total_entries,
         parser_stats: stats,
         unclaimed,
@@ -235,6 +252,16 @@ fn format_report(reports: &[FileReport]) -> String {
     let mut total_double_claims: usize = 0;
 
     for report in reports {
+        if report.read_error {
+            let _ = writeln!(
+                out,
+                "File: {} — READ ERROR (unreadable file)",
+                report.filename
+            );
+            let _ = writeln!(out);
+            continue;
+        }
+
         let _ = writeln!(
             out,
             "File: {} ({} entries)",
@@ -328,6 +355,7 @@ fn smoke_test_real_logs() {
     let _ = std::io::Write::write_all(&mut std::io::stdout(), report.as_bytes());
 
     // Aggregate totals for assertions.
+    let read_errors: usize = reports.iter().filter(|r| r.read_error).count();
     let total_panics: usize = reports
         .iter()
         .flat_map(|r| r.parser_stats.iter())
@@ -335,6 +363,10 @@ fn smoke_test_real_logs() {
         .sum();
     let total_double_claims: usize = reports.iter().map(|r| r.double_claims).sum();
 
+    assert_eq!(
+        read_errors, 0,
+        "unreadable log files detected \u{2014} see report above"
+    );
     assert_eq!(
         total_panics, 0,
         "parser panics detected \u{2014} see report above"


### PR DESCRIPTION
## Summary
- Add integration test that feeds real Player.log files through all 8 implemented parsers
- Env-var gated (`MANASIGHT_TEST_LOGS`) — skips gracefully when unset, zero CI cost on normal runs
- Add GitHub Actions workflow for manual and weekly scheduled smoke test runs

## Changes Made
- `tests/smoke_real_logs.rs` — integration test harness with per-parser attribution (claim counts, panic detection via `catch_unwind`, double-claim checking, timestamp failure tracking)
- `.github/workflows/smoke-test.yml` — manual `workflow_dispatch` trigger (accepts log archive URL) + weekly cron schedule, with artifact upload and log caching

## Testing
- All tests passing (586 tests — 585 existing + 1 new)
- Smoke test verified against 5 real Player.log files (11,227 entries total): zero panics, zero double claims
- Linting clean, formatted
- Code coverage: 95.83%, 1012/1056 lines covered

Fixes manasight/manasight-docs#164

🤖 Generated with [Claude Code](https://claude.com/claude-code)