### PR TITLE
Fix manasight/manasight-docs#165: draft_complete parser marker mismatch

### DIFF
--- a/src/parsers/draft/complete.rs
+++ b/src/parsers/draft/complete.rs
@@ -1,12 +1,13 @@
-//! Draft completion parser for `Draft_CompleteDraft` events.
+//! Draft completion parser for `DraftCompleteDraft` events.
 //!
 //! When a draft finishes (all picks made), the log emits a
-//! `Draft_CompleteDraft` entry that links the draft ID to the event
-//! and marks the draft as finished.
+//! `DraftCompleteDraft` entry that links the draft ID to the event
+//! and marks the draft as finished. Two entry formats appear:
 //!
-//! | Signature | Meaning | Key Fields |
-//! |-----------|---------|------------|
-//! | `Draft_CompleteDraft` | Draft finished | `DraftId`, `EventName` |
+//! | Direction | Format | Key Fields |
+//! |-----------|--------|------------|
+//! | Request (`==>`) | `{"id": "...", "request": "{\"EventName\": \"...\"}"}` | `id`, nested `EventName` |
+//! | Response (`<==`) | `{"CourseId": "...", "InternalEventName": "...", "CardPool": [...]}` | `InternalEventName`, `CardPool` |
 //!
 //! This is a Class 2 (Durable Per-Event) event. The completion signal
 //! must survive crashes to ensure the draft record is finalized.
@@ -16,14 +17,15 @@ use crate::log::entry::LogEntry;
 
 /// Marker for draft completion events.
 ///
-/// `Draft_CompleteDraft` appears in the log when the player finishes
-/// drafting all cards (all 42 picks made).
-const COMPLETE_DRAFT_MARKER: &str = "Draft_CompleteDraft";
+/// `DraftCompleteDraft` appears in the log when the player finishes
+/// drafting all cards (all 42 picks made). Both request (`==>`) and
+/// response (`<==`) entries share this marker.
+const COMPLETE_DRAFT_MARKER: &str = "DraftCompleteDraft";
 
 /// Attempts to parse a [`LogEntry`] as a draft completion event.
 ///
 /// Returns `Some(GameEvent::DraftComplete(_))` if the entry matches the
-/// `Draft_CompleteDraft` signature, or `None` if it does not match.
+/// `DraftCompleteDraft` signature, or `None` if it does not match.
 ///
 /// The `timestamp` is used to construct [`EventMetadata`] for the resulting
 /// event. Callers are responsible for parsing the timestamp from the log
@@ -40,12 +42,13 @@ pub fn try_parse(entry: &LogEntry, timestamp: chrono::DateTime<chrono::Utc>) -> 
     let parsed: serde_json::Value = match serde_json::from_str(json_str) {
         Ok(v) => v,
         Err(e) => {
-            ::log::warn!("Draft_CompleteDraft: malformed JSON payload: {e}");
+            ::log::warn!("DraftCompleteDraft: malformed JSON payload: {e}");
             return None;
         }
     };
 
-    let payload = build_payload(&parsed);
+    let draft_id_from_body = extract_draft_id_from_body(body);
+    let payload = build_payload(&parsed, draft_id_from_body.as_deref());
     let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
     Some(GameEvent::DraftComplete(DraftCompleteEvent::new(
         metadata, payload,
@@ -54,20 +57,36 @@ pub fn try_parse(entry: &LogEntry, timestamp: chrono::DateTime<chrono::Utc>) -> 
 
 /// Builds a structured payload from the draft completion event.
 ///
-/// Extracts key fields into a flat payload for downstream consumers.
-/// Falls back to empty/default values for any missing fields.
-fn build_payload(parsed: &serde_json::Value) -> serde_json::Value {
+/// Handles three JSON formats:
+/// - **Request**: `{"id": "...", "request": "{\"EventName\": \"...\"}"}` — event name
+///   is extracted from the string-escaped `request` field.
+/// - **Response**: `{"CourseId": "...", "InternalEventName": "..."}` — event name is
+///   a direct field, draft ID comes from the body header.
+/// - **Flat** (legacy): `{"DraftId": "...", "EventName": "..."}` — both fields at
+///   top level.
+fn build_payload(
+    parsed: &serde_json::Value,
+    draft_id_from_body: Option<&str>,
+) -> serde_json::Value {
     let draft_id = parsed
         .get("DraftId")
         .or_else(|| parsed.get("draftId"))
+        .or_else(|| parsed.get("id"))
         .and_then(serde_json::Value::as_str)
+        .or(draft_id_from_body)
         .unwrap_or("");
 
-    let event_name = parsed
+    let direct_event_name = parsed
         .get("EventName")
         .or_else(|| parsed.get("InternalEventName"))
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
+
+    let event_name = if direct_event_name.is_empty() {
+        event_name_from_request(parsed)
+    } else {
+        direct_event_name.to_owned()
+    };
 
     serde_json::json!({
         "type": "draft_complete",
@@ -75,6 +94,37 @@ fn build_payload(parsed: &serde_json::Value) -> serde_json::Value {
         "event_name": event_name,
         "raw_complete_draft": parsed.clone(),
     })
+}
+
+/// Extracts the draft ID from a `DraftCompleteDraft(uuid)` pattern in the body.
+///
+/// The response format includes the draft ID in a parenthesized suffix:
+/// `<== DraftCompleteDraft(2c141a6f-49e9-4b73-8231-47212fc8d577)`
+fn extract_draft_id_from_body(body: &str) -> Option<String> {
+    let marker = "DraftCompleteDraft(";
+    let start = body.find(marker)? + marker.len();
+    let remaining = body.get(start..)?;
+    let end = remaining.find(')')?;
+    Some(remaining.get(..end)?.to_owned())
+}
+
+/// Extracts `EventName` from a nested `request` field containing string-escaped JSON.
+///
+/// The request format stores the event name inside a string-encoded JSON object:
+/// `{"id": "...", "request": "{\"EventName\": \"PremierDraft_ECL_20260120\"}"}`
+fn event_name_from_request(parsed: &serde_json::Value) -> String {
+    let Some(request_str) = parsed.get("request").and_then(serde_json::Value::as_str) else {
+        return String::new();
+    };
+    let Ok(request_json) = serde_json::from_str::<serde_json::Value>(request_str) else {
+        return String::new();
+    };
+    request_json
+        .get("EventName")
+        .or_else(|| request_json.get("InternalEventName"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_owned()
 }
 
 /// Extracts the first JSON object or array from a multi-line log body.
@@ -182,14 +232,122 @@ mod tests {
         }
     }
 
-    // -- Basic draft completion parsing --------------------------------------
+    // -- Request format (==>) ------------------------------------------------
 
-    mod basic_parsing {
+    mod request_format {
         use super::*;
 
         #[test]
-        fn test_try_parse_draft_complete_basic() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_request_basic() {
+            let body = r#"[UnityCrossThreadLogger]==> DraftCompleteDraft {"id":"abc-123-def","request":"{\"EventName\":\"PremierDraft_MKM_20260201\",\"IsBotDraft\":false}"}"#;
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["type"], "draft_complete");
+            assert_eq!(payload["draft_id"], "abc-123-def");
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_try_parse_request_traditional_draft() {
+            let body = r#"[UnityCrossThreadLogger]==> DraftCompleteDraft {"id":"trad-456","request":"{\"EventName\":\"TradDraft_DSK_20260115\",\"IsBotDraft\":false}"}"#;
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["draft_id"], "trad-456");
+            assert_eq!(payload["event_name"], "TradDraft_DSK_20260115");
+        }
+
+        #[test]
+        fn test_try_parse_request_empty_request_string() {
+            let body = r#"[UnityCrossThreadLogger]==> DraftCompleteDraft {"id":"empty-req","request":"{}"}"#;
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["draft_id"], "empty-req");
+            assert_eq!(payload["event_name"], "");
+        }
+    }
+
+    // -- Response format (<==) -----------------------------------------------
+
+    mod response_format {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_response_basic() {
+            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
+                         <== DraftCompleteDraft(abc-123-def)\n\
+                         {\"CourseId\":\"course-456\",\
+                          \"InternalEventName\":\"PremierDraft_MKM_20260201\",\
+                          \"CurrentModule\":\"DeckSelect\",\
+                          \"CardPool\":[98535,98381]}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["type"], "draft_complete");
+            assert_eq!(payload["draft_id"], "abc-123-def");
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_try_parse_response_preserves_card_pool() {
+            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
+                         <== DraftCompleteDraft(pool-test)\n\
+                         {\"InternalEventName\":\"PremierDraft_ECL_20260120\",\
+                          \"CardPool\":[98535,98381,98366]}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            let raw = &payload["raw_complete_draft"];
+            assert_eq!(raw["CardPool"][0], 98535);
+            assert_eq!(raw["CardPool"][2], 98366);
+        }
+
+        #[test]
+        fn test_try_parse_response_event_name_fallback() {
+            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
+                         <== DraftCompleteDraft(fallback-test)\n\
+                         {\"EventName\":\"QuickDraft_MKM_20260201\"}";
+            let entry = unity_entry(body);
+            let result = try_parse(&entry, test_timestamp());
+
+            assert!(result.is_some());
+            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let payload = draft_complete_payload(event);
+
+            assert_eq!(payload["event_name"], "QuickDraft_MKM_20260201");
+        }
+    }
+
+    // -- Flat/legacy format --------------------------------------------------
+
+    mod flat_format {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_flat_basic() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\n\
                            \"DraftId\": \"abc-123-def\",\n\
                            \"EventName\": \"PremierDraft_MKM_20260201\"\n\
@@ -207,8 +365,8 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_draft_complete_traditional() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_flat_traditional() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\n\
                            \"DraftId\": \"trad-456\",\n\
                            \"EventName\": \"TradDraft_DSK_20260115\"\n\
@@ -225,8 +383,8 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_draft_complete_quick_draft() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_flat_quick_draft() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\n\
                            \"DraftId\": \"quick-789\",\n\
                            \"EventName\": \"QuickDraft_MKM_20260201\"\n\
@@ -243,8 +401,8 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_draft_complete_lowercase_draft_id() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_flat_lowercase_draft_id() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\n\
                            \"draftId\": \"lowercase-123\",\n\
                            \"EventName\": \"PremierDraft_MKM_20260201\"\n\
@@ -260,8 +418,8 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_draft_complete_internal_event_name() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_flat_internal_event_name() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\n\
                            \"DraftId\": \"intern-456\",\n\
                            \"InternalEventName\": \"PremierDraft_MKM_20260201\"\n\
@@ -283,8 +441,8 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_try_parse_draft_complete_missing_draft_id() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_missing_draft_id() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\n\
                            \"EventName\": \"PremierDraft_MKM_20260201\"\n\
                          }";
@@ -300,8 +458,8 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_draft_complete_missing_event_name() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_missing_event_name() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\n\
                            \"DraftId\": \"no-event-name\"\n\
                          }";
@@ -317,8 +475,8 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_draft_complete_minimal_payload() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_minimal_payload() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {}";
             let entry = unity_entry(body);
             let result = try_parse(&entry, test_timestamp());
@@ -338,10 +496,8 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_try_parse_draft_complete_preserves_raw_bytes() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
-                         {\"DraftId\": \"raw-test\", \
-                          \"EventName\": \"PremierDraft_MKM_20260201\"}";
+        fn test_try_parse_preserves_raw_bytes() {
+            let body = r#"[UnityCrossThreadLogger]==> DraftCompleteDraft {"id":"raw-test","request":"{\"EventName\":\"PremierDraft_MKM_20260201\"}"}"#;
             let entry = unity_entry(body);
             let result = try_parse(&entry, test_timestamp());
 
@@ -351,8 +507,8 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_draft_complete_stores_timestamp() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_stores_timestamp() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\"DraftId\": \"ts-test\"}";
             let entry = unity_entry(body);
             let ts = test_timestamp();
@@ -364,8 +520,8 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_draft_complete_preserves_raw_payload() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+        fn test_try_parse_preserves_raw_payload() {
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\n\
                            \"DraftId\": \"raw-payload\",\n\
                            \"ExtraField\": \"preserved\"\n\
@@ -419,7 +575,7 @@ mod tests {
 
         #[test]
         fn test_try_parse_malformed_json_returns_none() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {broken json!!!}";
             let entry = unity_entry(body);
             assert!(try_parse(&entry, test_timestamp()).is_none());
@@ -427,7 +583,7 @@ mod tests {
 
         #[test]
         fn test_try_parse_marker_only_no_json_returns_none() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft";
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft";
             let entry = unity_entry(body);
             assert!(try_parse(&entry, test_timestamp()).is_none());
         }
@@ -440,6 +596,15 @@ mod tests {
             };
             assert!(try_parse(&entry, test_timestamp()).is_none());
         }
+
+        #[test]
+        fn test_try_parse_old_underscore_marker_returns_none() {
+            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+                         {\"DraftId\": \"old-marker\", \
+                          \"EventName\": \"PremierDraft_MKM_20260201\"}";
+            let entry = unity_entry(body);
+            assert!(try_parse(&entry, test_timestamp()).is_none());
+        }
     }
 
     // -- Header with timestamp -----------------------------------------------
@@ -448,9 +613,9 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_try_parse_draft_complete_with_timestamp_prefix() {
+        fn test_try_parse_with_timestamp_prefix() {
             let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM \
-                         Draft_CompleteDraft\n\
+                         DraftCompleteDraft\n\
                          {\"DraftId\": \"ts-prefix\", \
                           \"EventName\": \"PremierDraft_MKM_20260201\"}";
             let entry = unity_entry(body);
@@ -472,7 +637,7 @@ mod tests {
 
         #[test]
         fn test_draft_complete_event_is_durable_per_event() {
-            let body = "[UnityCrossThreadLogger]Draft_CompleteDraft\n\
+            let body = "[UnityCrossThreadLogger]DraftCompleteDraft\n\
                          {\"DraftId\": \"perf-test\"}";
             let entry = unity_entry(body);
             let result = try_parse(&entry, test_timestamp());
@@ -508,12 +673,36 @@ mod tests {
         }
 
         #[test]
-        fn test_build_payload_full() {
+        fn test_build_payload_request_format() {
+            let parsed = serde_json::json!({
+                "id": "req-123",
+                "request": "{\"EventName\":\"PremierDraft_MKM_20260201\",\"IsBotDraft\":false}"
+            });
+            let payload = build_payload(&parsed, None);
+            assert_eq!(payload["type"], "draft_complete");
+            assert_eq!(payload["draft_id"], "req-123");
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_build_payload_response_format() {
+            let parsed = serde_json::json!({
+                "CourseId": "course-456",
+                "InternalEventName": "PremierDraft_MKM_20260201",
+                "CurrentModule": "DeckSelect"
+            });
+            let payload = build_payload(&parsed, Some("resp-789"));
+            assert_eq!(payload["draft_id"], "resp-789");
+            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
+        }
+
+        #[test]
+        fn test_build_payload_flat_format() {
             let parsed = serde_json::json!({
                 "DraftId": "test-id",
                 "EventName": "PremierDraft_MKM_20260201"
             });
-            let payload = build_payload(&parsed);
+            let payload = build_payload(&parsed, None);
             assert_eq!(payload["type"], "draft_complete");
             assert_eq!(payload["draft_id"], "test-id");
             assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
@@ -522,9 +711,52 @@ mod tests {
         #[test]
         fn test_build_payload_empty() {
             let parsed = serde_json::json!({});
-            let payload = build_payload(&parsed);
+            let payload = build_payload(&parsed, None);
             assert_eq!(payload["draft_id"], "");
             assert_eq!(payload["event_name"], "");
+        }
+
+        #[test]
+        fn test_extract_draft_id_from_body_response() {
+            let body = "<== DraftCompleteDraft(abc-123-def)\n{\"some\":\"json\"}";
+            assert_eq!(
+                extract_draft_id_from_body(body),
+                Some("abc-123-def".to_owned()),
+            );
+        }
+
+        #[test]
+        fn test_extract_draft_id_from_body_request_returns_none() {
+            let body = r#"==> DraftCompleteDraft {"id":"abc-123-def"}"#;
+            assert!(extract_draft_id_from_body(body).is_none());
+        }
+
+        #[test]
+        fn test_extract_draft_id_from_body_no_marker() {
+            assert!(extract_draft_id_from_body("no marker here").is_none());
+        }
+
+        #[test]
+        fn test_event_name_from_request_valid() {
+            let parsed = serde_json::json!({
+                "request": "{\"EventName\":\"PremierDraft_ECL_20260120\"}"
+            });
+            assert_eq!(
+                event_name_from_request(&parsed),
+                "PremierDraft_ECL_20260120",
+            );
+        }
+
+        #[test]
+        fn test_event_name_from_request_no_field() {
+            let parsed = serde_json::json!({"id": "test"});
+            assert_eq!(event_name_from_request(&parsed), "");
+        }
+
+        #[test]
+        fn test_event_name_from_request_invalid_json() {
+            let parsed = serde_json::json!({"request": "not json"});
+            assert_eq!(event_name_from_request(&parsed), "");
         }
     }
 }

--- a/src/parsers/draft/mod.rs
+++ b/src/parsers/draft/mod.rs
@@ -6,7 +6,7 @@
 //! |--------|---------------|------------|
 //! | [`bot`] | `DraftStatus: "PickNext"`, `BotDraft_DraftPick` | [`DraftBotEvent`](crate::events::DraftBotEvent) |
 //! | [`human`] | `Draft.Notify`, `EventPlayerDraftMakePick`, `LogBusinessEvents` with `PickGrpId` | [`DraftHumanEvent`](crate::events::DraftHumanEvent) |
-//! | [`complete`] | `Draft_CompleteDraft` | [`DraftCompleteEvent`](crate::events::DraftCompleteEvent) |
+//! | [`complete`] | `DraftCompleteDraft` | [`DraftCompleteEvent`](crate::events::DraftCompleteEvent) |
 
 pub mod bot;
 pub mod complete;


### PR DESCRIPTION
## Summary
- Fix marker constant from `Draft_CompleteDraft` (underscore) to `DraftCompleteDraft` (no underscore) to match real MTGA log output
- Handle request format (`==>`) with nested string-escaped JSON in `request` field
- Handle response format (`<==`) with `DraftCompleteDraft(uuid)` header pattern and direct `InternalEventName` field
- Preserve backward compatibility with flat `{"DraftId": "...", "EventName": "..."}` format

## Changes Made
- `src/parsers/draft/complete.rs`: Updated marker constant, added `extract_draft_id_from_body` and `event_name_from_request` helpers, updated `build_payload` to handle three JSON formats (request, response, flat/legacy), rewrote tests organized by format with 35 unit tests
- `src/parsers/draft/mod.rs`: Updated module doc table to reflect corrected marker name

## Testing
- All tests passing (600 unit + integration tests)
- Linting clean, formatted
- Code coverage: 96.28% coverage, 1035/1075 lines covered, +0.45% change
- Smoke test against real Player.log files: `draft_complete` now claims 2 entries in `session_2026-02-22_b.log` (was 0), zero panics, zero double claims

Closes manasight/manasight-docs#165

🤖 Generated with [Claude Code](https://claude.com/claude-code)