### PR TITLE
Fix manasight/manasight-parser#41: process all batched GSMs in GRE events

### DIFF
--- a/src/parsers/gre/annotations.rs
+++ b/src/parsers/gre/annotations.rs
@@ -358,7 +358,10 @@ mod tests {
         fn test_annotations_present_is_array() {
             let body = game_state_message_with_annotations_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             assert!(payload["annotations"].is_array());
@@ -368,7 +371,10 @@ mod tests {
         fn test_annotations_count_three() {
             let body = game_state_message_with_annotations_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let annotations = payload["annotations"]
@@ -381,7 +387,10 @@ mod tests {
         fn test_single_annotation_base_fields() {
             let body = game_state_message_with_single_annotation_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let annotations = payload["annotations"]
@@ -399,7 +408,10 @@ mod tests {
         fn test_zone_transfer_fields() {
             let body = game_state_message_with_annotations_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -413,7 +425,10 @@ mod tests {
         fn test_object_id_changed_fields() {
             let body = game_state_message_with_annotations_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][1];
@@ -426,7 +441,10 @@ mod tests {
         fn test_unknown_annotation_type_passed_through() {
             let body = game_state_message_with_annotations_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][2];
@@ -457,7 +475,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let annotations = payload["annotations"]
@@ -470,7 +491,10 @@ mod tests {
         fn test_missing_annotations_returns_empty_array() {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let annotations = payload["annotations"]
@@ -483,7 +507,10 @@ mod tests {
         fn test_zone_transfer_missing_details_still_has_base_fields() {
             let body = game_state_message_with_missing_details_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let annotations = payload["annotations"]
@@ -501,7 +528,10 @@ mod tests {
         fn test_multiple_affected_ids() {
             let body = game_state_message_with_annotations_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             // Second annotation has two affected IDs.
@@ -536,7 +566,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -570,7 +603,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -588,7 +624,10 @@ mod tests {
         fn test_single_type_annotation_has_types_array() {
             let body = game_state_message_with_single_annotation_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -634,7 +673,10 @@ mod tests {
         fn test_damage_dealt_damage_amount() {
             let body = damage_dealt_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -646,7 +688,10 @@ mod tests {
         fn test_damage_dealt_damage_type() {
             let body = damage_dealt_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -657,7 +702,10 @@ mod tests {
         fn test_damage_dealt_affector_and_affected() {
             let body = damage_dealt_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -692,7 +740,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -735,7 +786,10 @@ mod tests {
         fn test_counter_added_type() {
             let body = counter_added_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -747,7 +801,10 @@ mod tests {
         fn test_counter_added_amount() {
             let body = counter_added_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -758,7 +815,10 @@ mod tests {
         fn test_counter_added_affector_and_affected() {
             let body = counter_added_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -803,7 +863,10 @@ mod tests {
         fn test_target_spec_ability_grp_id() {
             let body = target_spec_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -815,7 +878,10 @@ mod tests {
         fn test_target_spec_index() {
             let body = target_spec_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -826,7 +892,10 @@ mod tests {
         fn test_target_spec_affector_and_affected() {
             let body = target_spec_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -864,7 +933,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];
@@ -898,7 +970,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ann = &payload["annotations"][0];

--- a/src/parsers/gre/connect_resp.rs
+++ b/src/parsers/gre/connect_resp.rs
@@ -122,8 +122,8 @@ mod tests {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let deck_cards = payload["deck_cards"].as_array();
@@ -142,8 +142,8 @@ mod tests {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let sideboard = payload["sideboard_cards"].as_array();
@@ -160,8 +160,8 @@ mod tests {
             let body = minimal_connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let sideboard = payload["sideboard_cards"].as_array();
@@ -175,8 +175,8 @@ mod tests {
             let body = minimal_connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let deck_cards = payload["deck_cards"].as_array();
@@ -198,8 +198,8 @@ mod tests {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let seat_ids = payload["system_seat_ids"].as_array();
@@ -215,8 +215,8 @@ mod tests {
             let body = flat_connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let seat_ids = payload["system_seat_ids"].as_array();
@@ -236,8 +236,8 @@ mod tests {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert!(payload["settings"].is_object());
@@ -252,8 +252,8 @@ mod tests {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(
@@ -267,8 +267,8 @@ mod tests {
             let body = minimal_connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert!(payload["settings"].is_object());
@@ -283,8 +283,8 @@ mod tests {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["msg_id"], 1);
         }
@@ -294,8 +294,8 @@ mod tests {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["game_state_id"], 0);
         }
@@ -324,8 +324,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             // Deck cards should be empty when deckMessage is missing.
             let deck_cards = payload["deck_cards"].as_array();
@@ -351,8 +351,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             // Should still parse but with empty deck/sideboard.
             let deck_cards = payload["deck_cards"].as_array();
@@ -384,8 +384,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             let deck_cards = payload["deck_cards"].as_array();
             assert!(deck_cards.is_some());
@@ -414,8 +414,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             let seat_ids = payload["system_seat_ids"].as_array();
             assert!(seat_ids.is_some());
@@ -449,8 +449,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             // ConnectResp has priority over GameStateMessage.
             assert_eq!(payload["type"], "connect_resp");
@@ -483,8 +483,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["type"], "connect_resp");
         }

--- a/src/parsers/gre/game_result.rs
+++ b/src/parsers/gre/game_result.rs
@@ -174,22 +174,28 @@ mod tests {
         fn test_try_parse_game_state_message_game_over_emits_game_result() {
             let entry = unity_entry(&game_over_body());
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             assert!(matches!(event, GameEvent::GameResult(_)));
         }
 
         #[test]
         fn test_try_parse_game_over_performance_class_post_game_batch() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             assert_eq!(event.performance_class(), PerformanceClass::PostGameBatch);
         }
 
         #[test]
         fn test_try_parse_game_over_payload_type_and_source() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_result_payload(&event);
             assert_eq!(payload["type"], "game_result");
             assert_eq!(payload["source"], "gre_game_state");
@@ -198,7 +204,10 @@ mod tests {
         #[test]
         fn test_try_parse_game_over_extracts_stage_and_match_state() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_result_payload(&event);
             assert_eq!(payload["stage"], "GameStage_GameOver");
             assert_eq!(payload["match_state"], "MatchState_GameComplete");
@@ -207,7 +216,10 @@ mod tests {
         #[test]
         fn test_try_parse_game_over_extracts_winning_team_id() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_result_payload(&event);
             assert_eq!(payload["winning_team_id"], 1);
         }
@@ -215,7 +227,10 @@ mod tests {
         #[test]
         fn test_try_parse_game_over_extracts_result_type() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_result_payload(&event);
             assert_eq!(payload["result_type"], "ResultType_WinLoss");
         }
@@ -223,7 +238,10 @@ mod tests {
         #[test]
         fn test_try_parse_game_over_extracts_reason() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_result_payload(&event);
             assert_eq!(payload["reason"], "ResultReason_Game");
         }
@@ -231,7 +249,10 @@ mod tests {
         #[test]
         fn test_try_parse_game_over_preserves_results_array() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_result_payload(&event);
             let results = payload["results"]
                 .as_array()
@@ -243,7 +264,10 @@ mod tests {
         #[test]
         fn test_try_parse_game_over_preserves_raw_game_info() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_result_payload(&event);
             let gi = &payload["game_info"];
             assert_eq!(gi["matchID"], "match-abc-123");
@@ -254,7 +278,10 @@ mod tests {
         #[test]
         fn test_try_parse_game_over_preserves_timestamp() {
             let entry = unity_entry(&game_over_body());
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             assert_eq!(event.metadata().timestamp(), Some(test_timestamp()));
         }
 
@@ -262,7 +289,10 @@ mod tests {
         fn test_try_parse_game_over_preserves_raw_bytes() {
             let body = game_over_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
         }
 
@@ -270,8 +300,8 @@ mod tests {
         fn test_try_parse_queued_game_state_message_game_over_emits_game_result() {
             let entry = unity_entry(&queued_game_over_body());
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             assert!(matches!(event, GameEvent::GameResult(_)));
             let payload = game_result_payload(event);
             assert_eq!(payload["winning_team_id"], 2);
@@ -283,8 +313,8 @@ mod tests {
             // GameStage_Play should still emit GameState, not GameResult.
             let entry = unity_entry(&game_state_message_body());
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             assert!(matches!(event, GameEvent::GameState(_)));
         }
 
@@ -308,7 +338,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             assert!(matches!(event, GameEvent::GameResult(_)));
             let payload = game_result_payload(&event);
             assert_eq!(payload["winning_team_id"], 0);
@@ -354,7 +387,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_result_payload(&event);
             // Top-level fields come from the MatchScope_Game entry.
             assert_eq!(payload["winning_team_id"], 0);
@@ -388,8 +424,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             assert!(matches!(event, GameEvent::GameState(_)));
         }
     }

--- a/src/parsers/gre/game_state.rs
+++ b/src/parsers/gre/game_state.rs
@@ -381,7 +381,7 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
+            assert!(!result.is_empty());
         }
 
         #[test]
@@ -389,8 +389,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             assert!(matches!(event, GameEvent::GameState(_)));
         }
 
@@ -399,8 +399,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["type"], "game_state_message");
         }
@@ -410,8 +410,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["msg_id"], 5);
         }
@@ -421,8 +421,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["game_state_id"], 42);
         }
@@ -432,8 +432,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
         }
 
@@ -443,8 +443,8 @@ mod tests {
             let entry = unity_entry(&body);
             let ts = Some(test_timestamp());
             let result = try_parse(&entry, ts);
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             assert_eq!(event.metadata().timestamp(), ts);
         }
     }
@@ -459,8 +459,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"].as_array();
@@ -474,8 +474,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -500,8 +500,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -521,8 +521,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -542,8 +542,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -562,8 +562,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -582,8 +582,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -603,8 +603,8 @@ mod tests {
             let body = empty_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"].as_array();
@@ -618,8 +618,8 @@ mod tests {
             let body = minimal_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -644,8 +644,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"].as_array();
@@ -659,8 +659,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -681,8 +681,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -701,8 +701,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -722,8 +722,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -742,8 +742,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -759,8 +759,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -784,8 +784,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -805,8 +805,8 @@ mod tests {
             let body = empty_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"].as_array();
@@ -820,8 +820,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -836,8 +836,8 @@ mod tests {
             let body = flat_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -864,8 +864,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert!(payload["game_info"].is_object());
@@ -876,8 +876,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(payload["game_info"]["matchID"], "match-id-12345");
@@ -888,8 +888,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(payload["game_info"]["stage"], "GameStage_Play");
@@ -900,8 +900,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(payload["game_info"]["mulliganType"], "MulliganType_London");
@@ -912,8 +912,8 @@ mod tests {
             let body = empty_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert!(payload["game_info"].is_null());
@@ -930,7 +930,7 @@ mod tests {
             let body = queued_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
+            assert!(!result.is_empty());
         }
 
         #[test]
@@ -938,8 +938,8 @@ mod tests {
             let body = queued_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["type"], "queued_game_state_message");
         }
@@ -949,8 +949,8 @@ mod tests {
             let body = queued_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["msg_id"], 7);
         }
@@ -960,8 +960,8 @@ mod tests {
             let body = queued_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -980,8 +980,8 @@ mod tests {
             let body = queued_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -1000,8 +1000,8 @@ mod tests {
             let body = queued_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
         }
     }
@@ -1037,8 +1037,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let zones = payload["zones"]
@@ -1076,8 +1076,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let objects = payload["game_objects"]
@@ -1121,8 +1121,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             // Should parse with empty zones and objects.
@@ -1158,8 +1158,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
             assert_eq!(payload["type"], "game_state_message");
         }
@@ -1200,8 +1200,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             // Zone without zoneId should be skipped.
@@ -1247,8 +1247,8 @@ mod tests {
             );
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             // Object without instanceId should be skipped.
@@ -1363,7 +1363,10 @@ mod tests {
         fn test_timers_present_is_array() {
             let body = game_state_with_timers_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             assert!(payload["timers"].is_array());
@@ -1373,7 +1376,10 @@ mod tests {
         fn test_timers_count() {
             let body = game_state_with_timers_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let timers = payload["timers"]
@@ -1386,7 +1392,10 @@ mod tests {
         fn test_timer_base_fields() {
             let body = game_state_with_timers_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let timer = &payload["timers"][0];
@@ -1400,7 +1409,10 @@ mod tests {
         fn test_timer_optional_fields_present() {
             let body = game_state_with_timers_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let timer = &payload["timers"][0];
@@ -1414,7 +1426,10 @@ mod tests {
         fn test_timer_optional_fields_absent() {
             let body = game_state_with_timers_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let timer = &payload["timers"][1];
@@ -1428,7 +1443,10 @@ mod tests {
         fn test_missing_timers_returns_empty_array() {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let timers = payload["timers"]
@@ -1465,7 +1483,10 @@ mod tests {
         fn test_diff_deleted_instance_ids_present() {
             let body = game_state_with_diff_deleted_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ids = payload["diff_deleted_instance_ids"]
@@ -1495,7 +1516,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ids = payload["diff_deleted_instance_ids"]
@@ -1508,7 +1532,10 @@ mod tests {
         fn test_diff_deleted_instance_ids_absent_returns_empty() {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ids = payload["diff_deleted_instance_ids"]
@@ -1535,7 +1562,10 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let event = try_parse(&entry, Some(test_timestamp())).unwrap_or_else(|| unreachable!());
+            let event = try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| unreachable!());
             let payload = game_state_payload(&event);
 
             let ids = payload["diff_deleted_instance_ids"]

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -100,17 +100,20 @@ const GAME_STAGE_GAME_OVER: &str = "GameStage_GameOver";
 // Public entry point
 // ---------------------------------------------------------------------------
 
-/// Attempts to parse a [`LogEntry`] as a GRE event.
+/// Attempts to parse a [`LogEntry`] as one or more GRE events.
 ///
 /// Dispatches to the appropriate sub-parser based on the GRE message type:
-/// - `GREMessageType_ConnectResp` -> `connect_resp` payload
+/// - `GREMessageType_ConnectResp` -> `connect_resp` payload (single)
 /// - `GREMessageType_GameStateMessage` -> `game_state_message` payload
 ///   (or `game_result` if `gameInfo.stage == GameStage_GameOver`)
 /// - `GREMessageType_QueuedGameStateMessage` -> same as `GameStateMessage`
 ///
-/// Returns `Some(GameEvent::GameState(_))` for normal game state updates,
-/// `Some(GameEvent::GameResult(_))` for game-over messages, or `None` if
-/// the entry does not match.
+/// Arena frequently batches multiple `GameStateMessage` entries into a
+/// single `greToClientMessages` array. This function iterates **all**
+/// matching messages and returns a `Vec<GameEvent>` — one event per
+/// message. `ConnectResp` and noise types remain single-event.
+///
+/// Returns an empty `Vec` if the entry does not match.
 ///
 /// The `timestamp` is `None` when the log entry header did not contain a
 /// parseable timestamp. It is passed through to [`EventMetadata`] so
@@ -118,50 +121,52 @@ const GAME_STAGE_GAME_OVER: &str = "GameStage_GameOver";
 pub fn try_parse(
     entry: &LogEntry,
     timestamp: Option<chrono::DateTime<chrono::Utc>>,
-) -> Option<GameEvent> {
+) -> Vec<GameEvent> {
     let body = &entry.body;
 
     // Quick check: bail early if the GRE marker is not present.
     if !body.contains(GRE_TO_CLIENT_MARKER) {
-        return None;
+        return Vec::new();
     }
 
     // Extract and parse the JSON payload from the body.
-    let parsed = api_common::parse_json_from_body(body, "greToClientEvent")?;
+    let Some(parsed) = api_common::parse_json_from_body(body, "greToClientEvent") else {
+        return Vec::new();
+    };
 
-    let messages = extract_gre_messages(&parsed)?;
+    let Some(messages) = extract_gre_messages(&parsed) else {
+        return Vec::new();
+    };
 
     // Try ConnectResp first (highest priority, emitted once at game start).
     if let Some(connect_resp_msg) = find_message_by_type(messages, CONNECT_RESP_TYPE) {
         let payload = connect_resp::build_connect_resp_payload(connect_resp_msg, &parsed);
         let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-        return Some(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
+        return vec![GameEvent::GameState(GameStateEvent::new(metadata, payload))];
     }
 
-    // Try GameStateMessage (most frequent during gameplay).
-    if let Some(gsm) = find_message_by_type(messages, GAME_STATE_MESSAGE_TYPE) {
-        let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-        if game_result::is_game_over(gsm) {
-            let payload = game_result::build_game_result_payload(gsm);
-            return Some(GameEvent::GameResult(GameResultEvent::new(
-                metadata, payload,
-            )));
+    // Iterate ALL GameStateMessage and QueuedGameStateMessage entries.
+    // Arena batches multiple GSMs into a single greToClientMessages array;
+    // processing only the first silently discards the majority of updates.
+    let mut events = Vec::new();
+    for msg in messages {
+        let msg_type = msg.get("type").and_then(serde_json::Value::as_str);
+        if let Some(GAME_STATE_MESSAGE_TYPE | QUEUED_GAME_STATE_MESSAGE_TYPE) = msg_type {
+            let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
+            if game_result::is_game_over(msg) {
+                let payload = game_result::build_game_result_payload(msg);
+                events.push(GameEvent::GameResult(GameResultEvent::new(
+                    metadata, payload,
+                )));
+            } else {
+                let payload = game_state::build_game_state_message_payload(msg);
+                events.push(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
+            }
         }
-        let payload = game_state::build_game_state_message_payload(gsm);
-        return Some(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
     }
 
-    // Try QueuedGameStateMessage (deferred game state, same structure).
-    if let Some(qgsm) = find_message_by_type(messages, QUEUED_GAME_STATE_MESSAGE_TYPE) {
-        let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-        if game_result::is_game_over(qgsm) {
-            let payload = game_result::build_game_result_payload(qgsm);
-            return Some(GameEvent::GameResult(GameResultEvent::new(
-                metadata, payload,
-            )));
-        }
-        let payload = game_state::build_game_state_message_payload(qgsm);
-        return Some(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
+    if !events.is_empty() {
+        return events;
     }
 
     // Check for low-value noise types (UIMessage, TimerStateMessage,
@@ -172,13 +177,13 @@ pub fn try_parse(
             ::log::trace!("greToClientEvent: claimed noise type {noise_type}");
             let payload = serde_json::json!({ "recognized_type": noise_type });
             let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-            return Some(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
+            return vec![GameEvent::GameState(GameStateEvent::new(metadata, payload))];
         }
     }
 
     // Unrecognized GRE message type — log and skip.
     ::log::debug!("greToClientEvent: no recognized message type found");
-    None
+    Vec::new()
 }
 
 // ---------------------------------------------------------------------------
@@ -229,28 +234,26 @@ mod tests {
         fn test_try_parse_connect_resp_detected() {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
         }
 
         #[test]
         fn test_try_parse_connect_resp_correct_variant() {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert!(matches!(event, GameEvent::GameState(_)));
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::GameState(_)));
         }
 
         #[test]
         fn test_try_parse_connect_resp_type_field() {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            let payload = game_state_payload(&results[0]);
             assert_eq!(payload["type"], "connect_resp");
         }
     }
@@ -264,18 +267,17 @@ mod tests {
         fn test_try_parse_flat_format_detected() {
             let body = flat_connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
         }
 
         #[test]
         fn test_try_parse_flat_format_deck_cards() {
             let body = flat_connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            let payload = game_state_payload(&results[0]);
 
             let deck_cards = payload["deck_cards"].as_array();
             assert!(deck_cards.is_some());
@@ -290,10 +292,9 @@ mod tests {
         fn test_try_parse_flat_format_sideboard() {
             let body = flat_connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            let payload = game_state_payload(&results[0]);
 
             let sideboard = payload["sideboard_cards"].as_array();
             assert!(sideboard.is_some());
@@ -306,10 +307,9 @@ mod tests {
         fn test_try_parse_flat_format_settings() {
             let body = flat_connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            let payload = game_state_payload(&results[0]);
 
             assert_eq!(
                 payload["settings"]["autoPassOption"],
@@ -321,10 +321,9 @@ mod tests {
         fn test_try_parse_flat_format_msg_id() {
             let body = flat_connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            let payload = game_state_payload(&results[0]);
             assert_eq!(payload["msg_id"], 2);
         }
 
@@ -332,10 +331,9 @@ mod tests {
         fn test_try_parse_flat_format_game_state_message() {
             let body = flat_game_state_message_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            let payload = game_state_payload(&results[0]);
             assert_eq!(payload["type"], "game_state_message");
             assert_eq!(payload["msg_id"], 3);
         }
@@ -350,10 +348,9 @@ mod tests {
         fn test_try_parse_connect_resp_preserves_raw_connect_resp() {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            let payload = game_state_payload(&results[0]);
 
             assert!(payload.get("raw_connect_resp").is_some());
             // The raw event should contain the greToClientEvent wrapper.
@@ -366,10 +363,9 @@ mod tests {
         fn test_try_parse_connect_resp_preserves_raw_bytes() {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].metadata().raw_bytes(), body.as_bytes());
         }
 
         #[test]
@@ -377,56 +373,55 @@ mod tests {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
             let ts = Some(test_timestamp());
-            let result = try_parse(&entry, ts);
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert_eq!(event.metadata().timestamp(), ts);
+            let results = try_parse(&entry, ts);
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].metadata().timestamp(), ts);
         }
     }
 
-    // -- Non-GRE entries (should return None) ---------------------------------
+    // -- Non-GRE entries (should return empty Vec) ----------------------------
 
     mod non_gre_entries {
         use super::*;
 
         #[test]
-        fn test_try_parse_unrelated_entry_returns_none() {
+        fn test_try_parse_unrelated_entry_returns_empty() {
             let body = "[UnityCrossThreadLogger]Updated account. DisplayName:Test";
             let entry = unity_entry(body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }
 
         #[test]
-        fn test_try_parse_empty_body_returns_none() {
+        fn test_try_parse_empty_body_returns_empty() {
             let body = "[UnityCrossThreadLogger]";
             let entry = unity_entry(body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }
 
         #[test]
-        fn test_try_parse_match_state_event_returns_none() {
+        fn test_try_parse_match_state_event_returns_empty() {
             let body = "[UnityCrossThreadLogger]matchGameRoomStateChangedEvent\n\
                          {\"matchGameRoomStateChangedEvent\": {\"gameRoomInfo\": {}}}";
             let entry = unity_entry(body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }
 
         #[test]
-        fn test_try_parse_no_json_body_returns_none() {
+        fn test_try_parse_no_json_body_returns_empty() {
             let body = "[UnityCrossThreadLogger]greToClientEvent with no json";
             let entry = unity_entry(body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }
 
         #[test]
-        fn test_try_parse_malformed_json_returns_none() {
+        fn test_try_parse_malformed_json_returns_empty() {
             let body = "[UnityCrossThreadLogger]greToClientEvent\n{invalid json}";
             let entry = unity_entry(body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }
 
         #[test]
-        fn test_try_parse_gre_event_without_messages_returns_none() {
+        fn test_try_parse_gre_event_without_messages_returns_empty() {
             let body = format!(
                 "[UnityCrossThreadLogger]greToClientEvent\n{}",
                 serde_json::json!({
@@ -436,11 +431,11 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }
 
         #[test]
-        fn test_try_parse_gre_event_empty_messages_returns_none() {
+        fn test_try_parse_gre_event_empty_messages_returns_empty() {
             let body = format!(
                 "[UnityCrossThreadLogger]greToClientEvent\n{}",
                 serde_json::json!({
@@ -450,7 +445,7 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }
 
         #[test]
@@ -475,15 +470,15 @@ mod tests {
                 header: EntryHeader::ClientGre,
                 body: body.clone(),
             };
-            // Note: This returns Some because the parser only checks the body
+            // Note: This returns events because the parser only checks the body
             // content, not the header type. The GRE marker is present in the
             // body. This is valid -- ConnectResp can appear under either header.
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
         }
 
         #[test]
-        fn test_try_parse_unknown_gre_message_type_returns_none() {
+        fn test_try_parse_unknown_gre_message_type_returns_empty() {
             let body = format!(
                 "[UnityCrossThreadLogger]greToClientEvent\n{}",
                 serde_json::json!({
@@ -498,7 +493,7 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }
     }
 
@@ -512,11 +507,10 @@ mod tests {
         fn test_try_parse_connect_resp_performance_class_interactive_dispatch() {
             let body = connect_resp_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
             assert_eq!(
-                event.performance_class(),
+                results[0].performance_class(),
                 PerformanceClass::InteractiveDispatch
             );
         }
@@ -525,11 +519,10 @@ mod tests {
         fn test_try_parse_game_state_message_performance_class_interactive_dispatch() {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
             assert_eq!(
-                event.performance_class(),
+                results[0].performance_class(),
                 PerformanceClass::InteractiveDispatch
             );
         }
@@ -538,11 +531,10 @@ mod tests {
         fn test_try_parse_queued_game_state_message_performance_class_interactive_dispatch() {
             let body = queued_game_state_message_body();
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
             assert_eq!(
-                event.performance_class(),
+                results[0].performance_class(),
                 PerformanceClass::InteractiveDispatch
             );
         }
@@ -643,24 +635,22 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_ui_message_returns_some() {
+        fn test_try_parse_ui_message_returns_event() {
             let entry = gre_entry_with_type("GREMessageType_UIMessage");
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert!(matches!(event, GameEvent::GameState(_)));
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::GameState(_)));
+            let payload = game_state_payload(&results[0]);
             assert_eq!(payload["recognized_type"], "GREMessageType_UIMessage");
         }
 
         #[test]
-        fn test_try_parse_timer_state_message_returns_some() {
+        fn test_try_parse_timer_state_message_returns_event() {
             let entry = gre_entry_with_type("GREMessageType_TimerStateMessage");
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert!(matches!(event, GameEvent::GameState(_)));
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::GameState(_)));
+            let payload = game_state_payload(&results[0]);
             assert_eq!(
                 payload["recognized_type"],
                 "GREMessageType_TimerStateMessage"
@@ -668,28 +658,27 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_set_settings_resp_returns_some() {
+        fn test_try_parse_set_settings_resp_returns_event() {
             let entry = gre_entry_with_type("GREMessageType_SetSettingsResp");
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert!(matches!(event, GameEvent::GameState(_)));
-            let payload = game_state_payload(event);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::GameState(_)));
+            let payload = game_state_payload(&results[0]);
             assert_eq!(payload["recognized_type"], "GREMessageType_SetSettingsResp");
         }
 
         #[test]
         fn test_noise_types_preserve_metadata_raw_bytes() {
             let entry = gre_entry_with_type("GREMessageType_UIMessage");
-            let result = try_parse(&entry, Some(test_timestamp()));
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert!(!event.metadata().raw_bytes().is_empty());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            assert!(!results[0].metadata().raw_bytes().is_empty());
         }
 
         #[test]
         fn test_noise_types_prioritize_real_events() {
             // If a message array has both a GameStateMessage and a UIMessage,
-            // the GameStateMessage should be returned (it comes first in dispatch).
+            // the GameStateMessage should be returned (GSMs are iterated first).
             let body = format!(
                 "[UnityCrossThreadLogger]greToClientEvent\n{}",
                 serde_json::json!({
@@ -712,18 +701,157 @@ mod tests {
                 })
             );
             let entry = unity_entry(&body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
             // Should be GameState from GameStateMessage, not from UIMessage noise
-            let payload = game_state_payload(event);
+            let payload = game_state_payload(&results[0]);
             assert!(payload.get("recognized_type").is_none());
         }
 
         #[test]
-        fn test_truly_unknown_type_still_returns_none() {
+        fn test_truly_unknown_type_still_returns_empty() {
             let entry = gre_entry_with_type("GREMessageType_SomeFutureType");
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
+            assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
+        }
+    }
+
+    // -- Batched message processing -------------------------------------------
+
+    mod batched_messages {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_batched_gsms_returns_all_events() {
+            let body = batched_game_state_messages_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 3);
+            for event in &results {
+                assert!(matches!(event, GameEvent::GameState(_)));
+            }
+        }
+
+        #[test]
+        fn test_try_parse_batched_gsms_preserve_msg_ids() {
+            let body = batched_game_state_messages_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 3);
+            let msg_ids: Vec<_> = results
+                .iter()
+                .map(|e| game_state_payload(e)["msg_id"].as_u64())
+                .collect();
+            assert_eq!(msg_ids, vec![Some(10), Some(11), Some(12)]);
+        }
+
+        #[test]
+        fn test_try_parse_batched_gsms_preserve_game_state_ids() {
+            let body = batched_game_state_messages_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 3);
+            let gs_ids: Vec<_> = results
+                .iter()
+                .map(|e| game_state_payload(e)["game_state_id"].as_u64())
+                .collect();
+            assert_eq!(gs_ids, vec![Some(100), Some(101), Some(102)]);
+        }
+
+        #[test]
+        fn test_try_parse_batched_qgsms_returns_all_events() {
+            let body = batched_queued_game_state_messages_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 2);
+            for event in &results {
+                assert!(matches!(event, GameEvent::GameState(_)));
+            }
+        }
+
+        #[test]
+        fn test_try_parse_mixed_gsm_qgsm_returns_all_events() {
+            let body = mixed_gsm_qgsm_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 2);
+            let msg_ids: Vec<_> = results
+                .iter()
+                .map(|e| game_state_payload(e)["msg_id"].as_u64())
+                .collect();
+            assert_eq!(msg_ids, vec![Some(30), Some(31)]);
+        }
+
+        #[test]
+        fn test_try_parse_batched_gsm_with_game_over_returns_mixed_types() {
+            let body = batched_gsm_with_game_over_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 2);
+            assert!(matches!(&results[0], GameEvent::GameState(_)));
+            assert!(matches!(&results[1], GameEvent::GameResult(_)));
+        }
+
+        #[test]
+        fn test_try_parse_gsm_plus_noise_ignores_noise() {
+            // When GSMs and noise types coexist, only GSMs produce events.
+            let body = format!(
+                "[UnityCrossThreadLogger]greToClientEvent\n{}",
+                serde_json::json!({
+                    "greToClientEvent": {
+                        "greToClientMessages": [
+                            {
+                                "type": "GREMessageType_TimerStateMessage",
+                                "data": {}
+                            },
+                            {
+                                "type": "GREMessageType_GameStateMessage",
+                                "msgId": 50,
+                                "gameStateId": 500,
+                                "gameStateMessage": {
+                                    "zones": [],
+                                    "gameObjects": [],
+                                    "gameInfo": {"stage": "GameStage_Play"}
+                                }
+                            },
+                            {
+                                "type": "GREMessageType_UIMessage",
+                                "data": {}
+                            }
+                        ]
+                    }
+                })
+            );
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 1);
+            let payload = game_state_payload(&results[0]);
+            assert_eq!(payload["msg_id"], 50);
+            assert!(payload.get("recognized_type").is_none());
+        }
+
+        #[test]
+        fn test_try_parse_batched_gsms_share_raw_bytes() {
+            // All events from a batch share the same raw_bytes (full entry).
+            let body = batched_game_state_messages_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 3);
+            let expected_bytes = body.as_bytes();
+            for event in &results {
+                assert_eq!(event.metadata().raw_bytes(), expected_bytes);
+            }
+        }
+
+        #[test]
+        fn test_try_parse_batched_gsms_share_timestamp() {
+            let body = batched_game_state_messages_body();
+            let entry = unity_entry(&body);
+            let ts = Some(test_timestamp());
+            let results = try_parse(&entry, ts);
+            assert_eq!(results.len(), 3);
+            for event in &results {
+                assert_eq!(event.metadata().timestamp(), ts);
+            }
         }
     }
 }

--- a/src/parsers/gre/test_fixtures.rs
+++ b/src/parsers/gre/test_fixtures.rs
@@ -225,6 +225,167 @@ pub(super) fn flat_game_state_message_body() -> String {
     )
 }
 
+/// Helper: build a GRE event body with **multiple** `GameStateMessage`
+/// entries in a single `greToClientMessages` array (batched).
+///
+/// This simulates the real-world scenario where Arena batches multiple
+/// game state updates into one log entry (55% of GRE events in live data).
+pub(super) fn batched_game_state_messages_body() -> String {
+    format!(
+        "[UnityCrossThreadLogger]greToClientEvent\n{}",
+        serde_json::json!({
+            "greToClientEvent": {
+                "greToClientMessages": [
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "msgId": 10,
+                        "gameStateId": 100,
+                        "gameStateMessage": {
+                            "zones": [
+                                {"zoneId": 30, "type": "ZoneType_Hand",
+                                 "ownerSeatId": 1, "objectInstanceIds": [101, 102]}
+                            ],
+                            "gameObjects": [],
+                            "gameInfo": {"stage": "GameStage_Play"}
+                        }
+                    },
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "msgId": 11,
+                        "gameStateId": 101,
+                        "gameStateMessage": {
+                            "zones": [
+                                {"zoneId": 32, "type": "ZoneType_Battlefield",
+                                 "ownerSeatId": 0, "objectInstanceIds": [301]}
+                            ],
+                            "gameObjects": [],
+                            "gameInfo": {"stage": "GameStage_Play"}
+                        }
+                    },
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "msgId": 12,
+                        "gameStateId": 102,
+                        "gameStateMessage": {
+                            "zones": [],
+                            "gameObjects": [],
+                            "gameInfo": {"stage": "GameStage_Play"}
+                        }
+                    }
+                ]
+            }
+        })
+    )
+}
+
+/// Helper: build a GRE event body with multiple `QueuedGameStateMessage`
+/// entries in a single batch.
+pub(super) fn batched_queued_game_state_messages_body() -> String {
+    format!(
+        "[UnityCrossThreadLogger]greToClientEvent\n{}",
+        serde_json::json!({
+            "greToClientEvent": {
+                "greToClientMessages": [
+                    {
+                        "type": "GREMessageType_QueuedGameStateMessage",
+                        "msgId": 20,
+                        "gameStateId": 200,
+                        "gameStateMessage": {
+                            "zones": [],
+                            "gameObjects": [],
+                            "gameInfo": {"stage": "GameStage_Play"}
+                        }
+                    },
+                    {
+                        "type": "GREMessageType_QueuedGameStateMessage",
+                        "msgId": 21,
+                        "gameStateId": 201,
+                        "gameStateMessage": {
+                            "zones": [],
+                            "gameObjects": [],
+                            "gameInfo": {"stage": "GameStage_Play"}
+                        }
+                    }
+                ]
+            }
+        })
+    )
+}
+
+/// Helper: build a GRE event body with mixed GSM and QGSM in one batch.
+pub(super) fn mixed_gsm_qgsm_body() -> String {
+    format!(
+        "[UnityCrossThreadLogger]greToClientEvent\n{}",
+        serde_json::json!({
+            "greToClientEvent": {
+                "greToClientMessages": [
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "msgId": 30,
+                        "gameStateId": 300,
+                        "gameStateMessage": {
+                            "zones": [],
+                            "gameObjects": [],
+                            "gameInfo": {"stage": "GameStage_Play"}
+                        }
+                    },
+                    {
+                        "type": "GREMessageType_QueuedGameStateMessage",
+                        "msgId": 31,
+                        "gameStateId": 301,
+                        "gameStateMessage": {
+                            "zones": [],
+                            "gameObjects": [],
+                            "gameInfo": {"stage": "GameStage_Play"}
+                        }
+                    }
+                ]
+            }
+        })
+    )
+}
+
+/// Helper: build a batched GRE event where one GSM has `GameStage_GameOver`.
+pub(super) fn batched_gsm_with_game_over_body() -> String {
+    format!(
+        "[UnityCrossThreadLogger]greToClientEvent\n{}",
+        serde_json::json!({
+            "greToClientEvent": {
+                "greToClientMessages": [
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "msgId": 40,
+                        "gameStateId": 400,
+                        "gameStateMessage": {
+                            "zones": [],
+                            "gameObjects": [],
+                            "gameInfo": {"stage": "GameStage_Play"}
+                        }
+                    },
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "msgId": 41,
+                        "gameStateId": 401,
+                        "gameStateMessage": {
+                            "zones": [],
+                            "gameObjects": [],
+                            "gameInfo": {
+                                "stage": "GameStage_GameOver",
+                                "matchID": "match-456",
+                                "gameNumber": 1,
+                                "results": [
+                                    {"scope": "MatchScope_Game", "result": "ResultType_Draw",
+                                     "winningTeamId": 0}
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        })
+    )
+}
+
 /// Helper: build a `GameStateMessage` with an empty `gameStateMessage`
 /// (no zones, no objects, no game info).
 pub(super) fn empty_game_state_message_body() -> String {

--- a/src/parsers/gre/turn_info.rs
+++ b/src/parsers/gre/turn_info.rs
@@ -143,8 +143,8 @@ mod tests {
             let body = game_state_message_with_turn_info_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert!(payload["turn_info"].is_object());
@@ -155,8 +155,8 @@ mod tests {
             let body = game_state_message_with_turn_info_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(payload["turn_info"]["turn_number"], 3);
@@ -167,8 +167,8 @@ mod tests {
             let body = game_state_message_with_turn_info_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(payload["turn_info"]["phase"], "Phase_Main1");
@@ -179,8 +179,8 @@ mod tests {
             let body = game_state_message_with_turn_info_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(payload["turn_info"]["step"], "Step_Upkeep");
@@ -191,8 +191,8 @@ mod tests {
             let body = game_state_message_with_turn_info_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(payload["turn_info"]["active_player"], 1);
@@ -203,8 +203,8 @@ mod tests {
             let body = game_state_message_with_turn_info_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert_eq!(payload["turn_info"]["decision_player"], 2);
@@ -215,8 +215,8 @@ mod tests {
             let body = game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert!(payload["turn_info"].is_null());
@@ -227,8 +227,8 @@ mod tests {
             let body = empty_game_state_message_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             assert!(payload["turn_info"].is_null());
@@ -239,8 +239,8 @@ mod tests {
             let body = game_state_message_with_partial_turn_info_body();
             let entry = unity_entry(&body);
             let result = try_parse(&entry, Some(test_timestamp()));
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
+            assert!(!result.is_empty());
+            let event = &result[0];
             let payload = game_state_payload(event);
 
             let turn_info = &payload["turn_info"];

--- a/src/router.rs
+++ b/src/router.rs
@@ -7,9 +7,10 @@
 //! # Dispatch strategy
 //!
 //! Each [`LogEntry`] is offered to category parsers in a fixed priority
-//! order (most frequent first). The first parser that returns
-//! `Some(GameEvent)` claims the entry. If no parser matches, the entry
-//! is counted as unrecognized and discarded.
+//! order (most frequent first). The first parser that returns one or
+//! more events claims the entry. GRE entries may produce multiple
+//! events from batched `GameStateMessage` values. If no parser matches,
+//! the entry is counted as unrecognized and discarded.
 //!
 //! # Timestamp extraction
 //!
@@ -104,8 +105,8 @@ impl RouterStats {
 ///     body: "[UnityCrossThreadLogger]some unrecognized line".to_owned(),
 /// };
 ///
-/// let event = router.route(&entry);
-/// assert!(event.is_none());
+/// let events = router.route(&entry);
+/// assert!(events.is_empty());
 /// assert_eq!(router.stats().unknown_count(), 1);
 /// ```
 pub struct Router {
@@ -129,15 +130,18 @@ impl Router {
     /// Routes a [`LogEntry`] to the appropriate parser.
     ///
     /// Extracts the timestamp from the entry header line, then offers the
-    /// entry to each category parser in priority order. Returns
-    /// `Some(GameEvent)` if a parser claims the entry, or `None` if the
-    /// entry is unrecognized.
+    /// entry to each category parser in priority order. Returns a
+    /// `Vec<GameEvent>` with one or more events if a parser claims the
+    /// entry, or an empty `Vec` if unrecognized.
+    ///
+    /// GRE entries may contain multiple batched `GameStateMessage` values
+    /// in a single log entry, producing multiple events from one entry.
     ///
     /// When the timestamp cannot be parsed, `None` is passed to parsers
     /// so downstream consumers can distinguish real timestamps from
     /// missing ones. The timestamp failure is counted in [`RouterStats`]
     /// and logged at debug level.
-    pub fn route(&self, entry: &LogEntry) -> Option<GameEvent> {
+    pub fn route(&self, entry: &LogEntry) -> Vec<GameEvent> {
         let timestamp = extract_timestamp(&entry.body);
 
         if timestamp.is_none() {
@@ -150,20 +154,20 @@ impl Router {
             );
         }
 
-        let event = dispatch_to_parsers(entry, timestamp);
+        let events = dispatch_to_parsers(entry, timestamp);
 
-        if event.is_some() {
-            self.stats.routed.fetch_add(1, Ordering::Relaxed);
-        } else {
+        if events.is_empty() {
             self.stats.unknown.fetch_add(1, Ordering::Relaxed);
             ::log::debug!(
                 "Unrecognized entry (header={}, body={:?})",
                 entry.header,
                 truncate_for_log(&entry.body, 120),
             );
+        } else {
+            self.stats.routed.fetch_add(1, Ordering::Relaxed);
         }
 
-        event
+        events
     }
 }
 
@@ -235,10 +239,21 @@ fn extract_timestamp(body: &str) -> Option<DateTime<Utc>> {
 /// 10. Collection — card collection from `StartHook`
 /// 11. Inventory — inventory from `StartHook`
 ///
+/// The GRE parser may return multiple events from a single entry
+/// (batched `GameStateMessage` values). All other parsers return at
+/// most one event.
+///
 /// `timestamp` is `None` when the log entry header did not contain a
 /// parseable timestamp; parsers pass it through to `EventMetadata`.
-fn dispatch_to_parsers(entry: &LogEntry, timestamp: Option<DateTime<Utc>>) -> Option<GameEvent> {
-    None.or_else(|| parsers::gre::try_parse(entry, timestamp))
+fn dispatch_to_parsers(entry: &LogEntry, timestamp: Option<DateTime<Utc>>) -> Vec<GameEvent> {
+    // GRE parser returns Vec<GameEvent> (may contain multiple batched GSMs).
+    let gre_events = parsers::gre::try_parse(entry, timestamp);
+    if !gre_events.is_empty() {
+        return gre_events;
+    }
+
+    // All other parsers return Option<GameEvent> (at most one event per entry).
+    let event = None
         .or_else(|| parsers::client_actions::try_parse(entry, timestamp))
         .or_else(|| parsers::match_state::try_parse(entry, timestamp))
         .or_else(|| parsers::session::try_parse(entry, timestamp))
@@ -248,7 +263,9 @@ fn dispatch_to_parsers(entry: &LogEntry, timestamp: Option<DateTime<Utc>>) -> Op
         .or_else(|| parsers::event_lifecycle::try_parse(entry, timestamp))
         .or_else(|| parsers::rank::try_parse(entry, timestamp))
         .or_else(|| parsers::collection::try_parse(entry, timestamp))
-        .or_else(|| parsers::inventory::try_parse(entry, timestamp))
+        .or_else(|| parsers::inventory::try_parse(entry, timestamp));
+
+    event.into_iter().collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -392,9 +409,9 @@ mod tests {
             let body = format!("[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n{payload}");
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::GameState(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::GameState(_)));
             assert_eq!(router.stats().routed_count(), 1);
             assert_eq!(router.stats().unknown_count(), 0);
         }
@@ -417,9 +434,9 @@ mod tests {
             let body = format!("[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n{payload}");
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::ClientAction(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::ClientAction(_)));
         }
 
         #[test]
@@ -439,9 +456,9 @@ mod tests {
             let body = format!("[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n{payload}");
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::MatchState(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::MatchState(_)));
         }
 
         #[test]
@@ -453,9 +470,9 @@ mod tests {
                          Token:sometoken";
             let entry = unity_entry(body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::Session(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::Session(_)));
         }
 
         #[test]
@@ -473,9 +490,9 @@ mod tests {
             );
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::Rank(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::Rank(_)));
         }
 
         #[test]
@@ -486,9 +503,9 @@ mod tests {
                          \"request\":\"{\\\"EventName\\\":\\\"PremierDraft_MKM\\\"}\"}";
             let entry = unity_entry(body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::EventLifecycle(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::EventLifecycle(_)));
         }
 
         #[test]
@@ -505,9 +522,9 @@ mod tests {
             );
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::DraftComplete(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::DraftComplete(_)));
         }
 
         #[test]
@@ -523,9 +540,9 @@ mod tests {
             let body = format!("[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n{payload}",);
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::DraftBot(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::DraftBot(_)));
         }
 
         #[test]
@@ -540,9 +557,9 @@ mod tests {
             let body = format!("[UnityCrossThreadLogger]Draft.Notify\n{payload}",);
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::DraftHuman(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::DraftHuman(_)));
         }
 
         #[test]
@@ -558,10 +575,10 @@ mod tests {
             );
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
             // StartHook with PlayerCards goes to Collection (tried before Inventory).
-            assert!(matches!(result, Some(GameEvent::Collection(_))));
+            assert!(matches!(&results[0], GameEvent::Collection(_)));
         }
 
         #[test]
@@ -576,10 +593,10 @@ mod tests {
             );
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
             // StartHook with InventoryInfo but no PlayerCards goes to Inventory.
-            assert!(matches!(result, Some(GameEvent::Inventory(_))));
+            assert!(matches!(&results[0], GameEvent::Inventory(_)));
         }
     }
 
@@ -589,14 +606,14 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_route_unknown_entry_returns_none() {
+        fn test_route_unknown_entry_returns_empty() {
             let router = Router::new();
             let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
                          some unrecognized content here";
             let entry = unity_entry(body);
 
-            let result = router.route(&entry);
-            assert!(result.is_none());
+            let results = router.route(&entry);
+            assert!(results.is_empty());
         }
 
         #[test]
@@ -626,14 +643,14 @@ mod tests {
         }
 
         #[test]
-        fn test_route_empty_body_after_header_returns_none() {
+        fn test_route_empty_body_after_header_returns_empty() {
             let router = Router::new();
             let body = "[UnityCrossThreadLogger]";
             let entry = unity_entry(body);
 
-            let result = router.route(&entry);
+            let results = router.route(&entry);
             // No timestamp -> passes None, but no parser matches.
-            assert!(result.is_none());
+            assert!(results.is_empty());
             assert_eq!(router.stats().timestamp_failure_count(), 1);
             assert_eq!(router.stats().unknown_count(), 1);
         }
@@ -644,9 +661,9 @@ mod tests {
             let body = "[UnityCrossThreadLogger]just some text without a timestamp";
             let entry = unity_entry(body);
 
-            let result = router.route(&entry);
+            let results = router.route(&entry);
             // No parseable timestamp and no parser claims this entry.
-            assert!(result.is_none());
+            assert!(results.is_empty());
             assert_eq!(router.stats().timestamp_failure_count(), 1);
             assert_eq!(router.stats().unknown_count(), 1);
         }
@@ -661,10 +678,10 @@ mod tests {
                          Token:token";
             let entry = unity_entry(body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
             // Session routed even without a timestamp in header.
-            assert!(matches!(result, Some(GameEvent::Session(_))));
+            assert!(matches!(&results[0], GameEvent::Session(_)));
             assert_eq!(router.stats().timestamp_failure_count(), 1);
             assert_eq!(router.stats().routed_count(), 1);
         }
@@ -680,14 +697,12 @@ mod tests {
                          Token:token";
             let entry = unity_entry(body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            if let Some(event) = &result {
-                assert!(
-                    event.metadata().timestamp().is_none(),
-                    "entries without parseable timestamps should have None timestamp"
-                );
-            }
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(
+                results[0].metadata().timestamp().is_none(),
+                "entries without parseable timestamps should have None timestamp"
+            );
         }
 
         #[test]
@@ -708,14 +723,12 @@ mod tests {
             let body = format!("[UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n{payload}");
             let entry = unity_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            if let Some(event) = &result {
-                assert!(
-                    event.metadata().timestamp().is_some(),
-                    "entries with parseable timestamps should have Some timestamp"
-                );
-            }
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(
+                results[0].metadata().timestamp().is_some(),
+                "entries with parseable timestamps should have Some timestamp"
+            );
         }
     }
 
@@ -814,9 +827,9 @@ mod tests {
             let body = format!("[Client GRE]2/25/2026 12:00:00 PM\n{payload}");
             let entry = gre_entry(&body);
 
-            let result = router.route(&entry);
-            assert!(result.is_some());
-            assert!(matches!(result, Some(GameEvent::GameState(_))));
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::GameState(_)));
         }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -242,7 +242,7 @@ async fn run_router(
     bus: EventBus,
 ) {
     while let Some(entry) = entry_rx.recv().await {
-        if let Some(event) = router.route(&entry) {
+        for event in router.route(&entry) {
             bus.send(event);
         }
     }

--- a/tests/smoke_common/mod.rs
+++ b/tests/smoke_common/mod.rs
@@ -26,10 +26,32 @@ const ENV_VAR: &str = "MANASIGHT_TEST_LOGS";
 // Types
 // ---------------------------------------------------------------------------
 
-/// A parser identified by name and its `try_parse` function pointer.
+/// Wrapper for parser function pointers with different return types.
+///
+/// Most parsers return `Option<GameEvent>` (single event per entry).
+/// The GRE parser returns `Vec<GameEvent>` (batched messages produce
+/// multiple events from one entry).
+pub enum ParserFunc {
+    /// A parser that returns at most one event per entry.
+    Single(fn(&LogEntry, Option<DateTime<Utc>>) -> Option<GameEvent>),
+    /// A parser that may return multiple events per entry.
+    Multi(fn(&LogEntry, Option<DateTime<Utc>>) -> Vec<GameEvent>),
+}
+
+impl ParserFunc {
+    /// Calls the parser and normalizes the result to a `Vec<GameEvent>`.
+    pub fn call(&self, entry: &LogEntry, ts: Option<DateTime<Utc>>) -> Vec<GameEvent> {
+        match self {
+            Self::Single(f) => f(entry, ts).into_iter().collect(),
+            Self::Multi(f) => f(entry, ts),
+        }
+    }
+}
+
+/// A parser identified by name and its `try_parse` function.
 pub struct NamedParser {
     pub name: &'static str,
-    pub func: fn(&LogEntry, Option<DateTime<Utc>>) -> Option<GameEvent>,
+    pub func: ParserFunc,
 }
 
 /// Per-parser statistics accumulated while processing a single log file.
@@ -50,47 +72,47 @@ pub fn all_parsers() -> Vec<NamedParser> {
     vec![
         NamedParser {
             name: "session",
-            func: parsers::session::try_parse,
+            func: ParserFunc::Single(parsers::session::try_parse),
         },
         NamedParser {
             name: "match_state",
-            func: parsers::match_state::try_parse,
+            func: ParserFunc::Single(parsers::match_state::try_parse),
         },
         NamedParser {
             name: "gre",
-            func: parsers::gre::try_parse,
+            func: ParserFunc::Multi(parsers::gre::try_parse),
         },
         NamedParser {
             name: "client_actions",
-            func: parsers::client_actions::try_parse,
+            func: ParserFunc::Single(parsers::client_actions::try_parse),
         },
         NamedParser {
             name: "draft_bot",
-            func: parsers::draft::bot::try_parse,
+            func: ParserFunc::Single(parsers::draft::bot::try_parse),
         },
         NamedParser {
             name: "draft_human",
-            func: parsers::draft::human::try_parse,
+            func: ParserFunc::Single(parsers::draft::human::try_parse),
         },
         NamedParser {
             name: "draft_complete",
-            func: parsers::draft::complete::try_parse,
+            func: ParserFunc::Single(parsers::draft::complete::try_parse),
         },
         NamedParser {
             name: "inventory",
-            func: parsers::inventory::try_parse,
+            func: ParserFunc::Single(parsers::inventory::try_parse),
         },
         NamedParser {
             name: "collection",
-            func: parsers::collection::try_parse,
+            func: ParserFunc::Single(parsers::collection::try_parse),
         },
         NamedParser {
             name: "rank",
-            func: parsers::rank::try_parse,
+            func: ParserFunc::Single(parsers::rank::try_parse),
         },
         NamedParser {
             name: "event_lifecycle",
-            func: parsers::event_lifecycle::try_parse,
+            func: ParserFunc::Single(parsers::event_lifecycle::try_parse),
         },
     ]
 }

--- a/tests/smoke_parsers.rs
+++ b/tests/smoke_parsers.rs
@@ -258,25 +258,25 @@ fn process_file(path: &Path, parsers: &[NamedParser]) -> FileReport {
 
         for (idx, parser) in parsers.iter().enumerate() {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                (parser.func)(entry, timestamp)
+                parser.func.call(entry, timestamp)
             }));
 
             match result {
-                Ok(Some(event)) => {
+                Ok(events) if !events.is_empty() => {
                     stats[idx].1.claimed += 1;
                     claimant_count += 1;
                     claimant_names.push(parser.name);
 
-                    // Track GSM field presence for GameState events.
-                    if let GameEvent::GameState(ref gs) = event {
-                        gsm_stats.track(gs.payload());
-                    }
+                    for event in &events {
+                        // Track GSM field presence for GameState events.
+                        if let GameEvent::GameState(ref gs) = event {
+                            gsm_stats.track(gs.payload());
+                        }
 
-                    *event_type_counts
-                        .entry(event_type_name(&event))
-                        .or_insert(0) += 1;
+                        *event_type_counts.entry(event_type_name(event)).or_insert(0) += 1;
+                    }
                 }
-                Ok(None) => {}
+                Ok(_) => {}
                 Err(_) => {
                     stats[idx].1.panics += 1;
                 }

--- a/tests/smoke_router.rs
+++ b/tests/smoke_router.rs
@@ -50,7 +50,7 @@ fn process_file_router(path: &Path) -> Option<RouterFileReport> {
     let mut event_type_counts: HashMap<&'static str, usize> = HashMap::new();
 
     for entry in &entries {
-        if let Some(event) = router.route(entry) {
+        for event in router.route(entry) {
             *event_type_counts
                 .entry(event_type_name(&event))
                 .or_insert(0) += 1;


### PR DESCRIPTION
## Summary
- Refactor GRE parser to iterate **all** `GameStateMessage` and `QueuedGameStateMessage` entries in batched `greToClientMessages` arrays, instead of only processing the first match
- Arena batches multiple GSMs into 55% of GRE events — the parser was silently discarding the majority of game state updates

## Changes Made
- `gre::try_parse()` now returns `Vec<GameEvent>` instead of `Option<GameEvent>`, iterating all GSM/QGSM messages per entry
- `Router::route()` and `dispatch_to_parsers()` updated to return `Vec<GameEvent>`
- `run_router()` in `stream.rs` iterates over multi-event results from the router
- `ParserFunc` enum added in smoke test infrastructure to support both single-event and multi-event parser signatures
- 4 new batched test fixtures (`batched_game_state_messages_body`, `batched_queued_game_state_messages_body`, `mixed_gsm_qgsm_body`, `batched_gsm_with_game_over_body`)
- 8 new tests covering batched processing, ordering, mixed types, noise suppression, and metadata sharing
- All existing tests updated to work with `Vec<GameEvent>` return type

## Testing
- All tests passing (792 tests: 775 unit + 10 integration + 7 doc-tests)
- Linting clean, formatted
- Code coverage: 97.63% coverage, 1194/1223 lines covered, +0.03% change in coverage

## Smoke Test Results (6 real log files, 11,998 entries)

**Status**: PASS (all 3 levels)

| Level | Events | Delta vs Previous |
|-------|--------|-------------------|
| L1 Parser (claims) | 11,191 | 0 |
| L2 Router (routed) | 11,191 | 0 |
| L3 Stream (events) | 12,585 | **+1,394** |

The claim/routed counts are unchanged — same log entries are matched. The stream now emits **+1,394 additional events** because batched GSMs produce individual events instead of being discarded.

Key event type changes (L1/L2):
- **GameState**: 6,175 → 10,522 (+4,347) — previously-discarded GSMs now processed
- **GameResult**: 11 → 30 (+19) — game-over messages in batched GRE events now captured

GSM enrichment also improved significantly (e.g. turn_info present: 256 → 1,991 for one file) since the additional GSMs carry their own annotations, timers, and diff data.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)