### PR TITLE
Add README and community files for open-source launch

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at support@enthrallcomputing.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to manasight-parser
+
+Contributions are welcome! Whether it's a bug report, feature suggestion, or pull request, we appreciate your help.
+
+## Reporting Bugs
+
+Open a [GitHub issue](https://github.com/manasight/manasight-parser/issues) with:
+
+- A clear description of the problem
+- Steps to reproduce (if applicable)
+- Relevant log output or error messages
+
+## Submitting Pull Requests
+
+1. Fork the repository and create a feature branch
+2. Make your changes
+3. Ensure all checks pass (see below)
+4. Open a pull request against `main`
+
+## Development Setup
+
+```bash
+git clone https://github.com/manasight/manasight-parser.git
+cd manasight-parser
+
+# Run tests
+cargo test --all-features
+
+# Lint
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Format
+cargo fmt --all
+```
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,70 @@
+> **This project is in active development.** APIs may change without notice.
+
 # manasight-parser
 
 MTG Arena log file parser — a Rust library crate that reads Arena's `Player.log` and emits typed game events via an async event bus.
 
-## Status
+## Architecture
 
-Under construction. Module structure is scaffolded; parsing logic is being implemented incrementally.
+```text
+Player.log → File Tailer → Entry Buffer → Router → Parsers → Event Bus
+```
+
+- **`log`** — file discovery, polling tailer, entry accumulation, timestamps
+- **`router`** — dispatches raw entries to the correct category parser
+- **`parsers`** — one sub-module per event category
+- **`events`** — public event type enums/structs (the parser's output contract)
+- **`event_bus`** — `tokio::broadcast` channel for fan-out to subscribers
+- **`stream`** — public entry point (`MtgaEventStream`)
+
+## Usage
+
+```rust
+use std::path::Path;
+use manasight_parser::MtgaEventStream;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (stream, mut subscriber) = MtgaEventStream::start(Path::new("Player.log")).await?;
+
+    while let Some(event) = subscriber.recv().await {
+        println!("got event: {event:?}");
+    }
+
+    Ok(())
+}
+```
+
+## Event Types
+
+| Event | Description | Class |
+|-------|-------------|-------|
+| `GameState` | GRE-to-client messages (zones, game objects, turns) | Interactive |
+| `ClientAction` | Client-to-GRE messages (mulligan, select, deck submit) | Interactive |
+| `MatchState` | Match room state changes (start, end, player seats) | Interactive |
+| `DraftBot` | Bot draft picks (Quick Draft) | Durable |
+| `DraftHuman` | Human draft picks (Premier/Traditional Draft) | Durable |
+| `DraftComplete` | Draft completion signal | Durable |
+| `EventLifecycle` | Event join, claim prize, enter pairing | Durable |
+| `Session` | Login, account identity, logout | Durable |
+| `Rank` | Constructed and limited rank snapshots | Durable |
+| `Collection` | Card collection snapshot | Durable |
+| `Inventory` | Currency, wildcards, boosters, vault progress | Durable |
+| `GameResult` | Game result / batch trigger | Post-game |
+
+### Performance Classes
+
+- **Interactive** (Class 1): local-only processing, ≤100ms latency target
+- **Durable** (Class 2): persisted to disk queue, ≤1s latency target
+- **Post-game** (Class 3): triggers assembly and upload of game batch
+
+## Minimum Supported Rust Version
+
+MSRV is 1.93.0.
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting bugs, submitting pull requests, and setting up a development environment.
 
 ## License
 
@@ -14,3 +74,5 @@ Licensed under either of
 - MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
+
+> This project is not affiliated with, endorsed by, or associated with Wizards of the Coast, Hasbro, or Magic: The Gathering Arena. All trademarks are the property of their respective owners.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in manasight-parser, please report it responsibly.
+
+**Email:** [support@enthrallcomputing.com](mailto:support@enthrallcomputing.com)
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Include as much detail as possible:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+We will respond as soon as possible and work with you to understand and address the issue.


### PR DESCRIPTION
## Summary
- Rewrites README from 16-line stub to full library crate documentation (architecture, usage example, event types table, MSRV, WotC disclaimer)
- Adds CONTRIBUTING.md with bug reporting and PR workflow
- Adds CODE_OF_CONDUCT.md (Contributor Covenant v2.1)
- Adds SECURITY.md with responsible disclosure process

Fixes manasight/manasight-docs#217
Fixes manasight/manasight-docs#220

## Test plan
- [ ] README renders correctly on GitHub
- [ ] All links in README resolve (LICENSE-APACHE, LICENSE-MIT, CONTRIBUTING.md)
- [ ] CODE_OF_CONDUCT.md links resolve
- [ ] SECURITY.md contact email is correct
- [ ] No Rust code changes — existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)