### PR TITLE
Fix manasight/manasight-docs#238: Add corpus manifest and baseline JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ Thumbs.db
 *.swp
 *.swo
 
+# Smoke test results (tracked via smoke-baseline.json, not committed)
+tests/smoke-results/
+
 # Claude Code — ignore symlinked workspace commands and runtime dirs
 .claude/commands/issue-to-merge.md
 .claude/commands/sequential-issues.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -475,6 +476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +566,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -744,6 +795,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ known-folders = "1"
 
 [dev-dependencies]
 tempfile = "3"
+toml = "0.8"
 
 [lints.clippy]
 # Pedantic lints as warnings

--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,0 +1,183 @@
+{
+  "_meta": {
+    "description": "Smoke test baseline — per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
+    "generated_from_commit": "8a62b96",
+    "corpus_tag": "smoke-data-v1"
+  },
+  "files": {
+    "session_2026-02-22_a.log": {
+      "total_entries": 4913,
+      "parsers": {
+        "session": 6,
+        "match_state": 10,
+        "gre": 2617,
+        "client_actions": 2026,
+        "draft_bot": 0,
+        "draft_human": 0,
+        "draft_complete": 0,
+        "inventory": 7,
+        "collection": 0,
+        "rank": 7,
+        "event_lifecycle": 6
+      },
+      "event_types": {
+        "ClientAction": 2026,
+        "EventLifecycle": 6,
+        "GameResult": 10,
+        "GameState": 4381,
+        "Inventory": 7,
+        "MatchState": 10,
+        "Rank": 7,
+        "Session": 6
+      },
+      "unclaimed": 234,
+      "double_claims": 0,
+      "timestamp_failures": 163
+    },
+    "session_2026-02-22_b.log": {
+      "total_entries": 3995,
+      "parsers": {
+        "session": 5,
+        "match_state": 8,
+        "gre": 2172,
+        "client_actions": 1488,
+        "draft_bot": 0,
+        "draft_human": 116,
+        "draft_complete": 2,
+        "inventory": 5,
+        "collection": 0,
+        "rank": 5,
+        "event_lifecycle": 6
+      },
+      "event_types": {
+        "ClientAction": 1488,
+        "DraftComplete": 2,
+        "DraftHuman": 116,
+        "EventLifecycle": 6,
+        "GameResult": 8,
+        "GameState": 3478,
+        "Inventory": 5,
+        "MatchState": 8,
+        "Rank": 5,
+        "Session": 5
+      },
+      "unclaimed": 188,
+      "double_claims": 0,
+      "timestamp_failures": 213
+    },
+    "session_2026-02-23.log": {
+      "total_entries": 948,
+      "parsers": {
+        "session": 3,
+        "match_state": 4,
+        "gre": 375,
+        "client_actions": 425,
+        "draft_bot": 0,
+        "draft_human": 0,
+        "draft_complete": 0,
+        "inventory": 3,
+        "collection": 0,
+        "rank": 3,
+        "event_lifecycle": 4
+      },
+      "event_types": {
+        "ClientAction": 425,
+        "EventLifecycle": 4,
+        "GameResult": 4,
+        "GameState": 808,
+        "Inventory": 3,
+        "MatchState": 4,
+        "Rank": 3,
+        "Session": 3
+      },
+      "unclaimed": 131,
+      "double_claims": 0,
+      "timestamp_failures": 89
+    },
+    "session_2026-03-05.log": {
+      "total_entries": 771,
+      "parsers": {
+        "session": 2,
+        "match_state": 2,
+        "gre": 454,
+        "client_actions": 236,
+        "draft_bot": 0,
+        "draft_human": 0,
+        "draft_complete": 0,
+        "inventory": 2,
+        "collection": 0,
+        "rank": 2,
+        "event_lifecycle": 2
+      },
+      "event_types": {
+        "ClientAction": 236,
+        "EventLifecycle": 2,
+        "GameResult": 2,
+        "GameState": 674,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 2
+      },
+      "unclaimed": 71,
+      "double_claims": 0,
+      "timestamp_failures": 48
+    },
+    "session_2026-03-06.log": {
+      "total_entries": 112,
+      "parsers": {
+        "session": 1,
+        "match_state": 0,
+        "gre": 0,
+        "client_actions": 0,
+        "draft_bot": 0,
+        "draft_human": 62,
+        "draft_complete": 2,
+        "inventory": 1,
+        "collection": 0,
+        "rank": 1,
+        "event_lifecycle": 1
+      },
+      "event_types": {
+        "DraftComplete": 2,
+        "DraftHuman": 62,
+        "EventLifecycle": 1,
+        "Inventory": 1,
+        "Rank": 1,
+        "Session": 1
+      },
+      "unclaimed": 44,
+      "double_claims": 0,
+      "timestamp_failures": 72
+    },
+    "session_2026-03-06_b.log": {
+      "total_entries": 2305,
+      "parsers": {
+        "session": 2,
+        "match_state": 2,
+        "gre": 1059,
+        "client_actions": 1157,
+        "draft_bot": 0,
+        "draft_human": 0,
+        "draft_complete": 0,
+        "inventory": 2,
+        "collection": 0,
+        "rank": 2,
+        "event_lifecycle": 1
+      },
+      "event_types": {
+        "ClientAction": 1157,
+        "EventLifecycle": 1,
+        "GameResult": 2,
+        "GameState": 1657,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 2
+      },
+      "unclaimed": 80,
+      "double_claims": 0,
+      "timestamp_failures": 55
+    }
+  }
+}

--- a/smoke-corpus-manifest.toml
+++ b/smoke-corpus-manifest.toml
@@ -1,0 +1,48 @@
+# Smoke test corpus manifest
+#
+# Describes the Player.log files used for smoke testing. The actual logs live
+# in a private GitHub release (manasight/manasight-test-data, tag smoke-data-v1)
+# to keep large binaries out of the parser repo. This manifest is committed so
+# that anyone can see what is tested and verify corpus integrity after download.
+#
+# Fields:
+#   filename       — name of the .log file inside the archive
+#   sha256         — hex-encoded SHA-256 hash of the file
+#   size_bytes     — file size in bytes
+#   date_captured  — date the play session was recorded (YYYY-MM-DD)
+
+[[files]]
+filename     = "session_2026-02-22_a.log"
+sha256       = "ec5579b89549ba09e1e7169fd512ea354535626ccd7188bd06e107bce1f635bb"
+size_bytes   = 31194170
+date_captured = "2026-02-22"
+
+[[files]]
+filename     = "session_2026-02-22_b.log"
+sha256       = "c760ae08d5d20b7089d41c81d0e60ff5079df9f8c99c14adfd849aadc8f3c52f"
+size_bytes   = 23726538
+date_captured = "2026-02-22"
+
+[[files]]
+filename     = "session_2026-02-23.log"
+sha256       = "bc0817fa05b5abca114d1484235b6f361eadc3aa4b1ee2a1631655a0e01c7a50"
+size_bytes   = 16111137
+date_captured = "2026-02-23"
+
+[[files]]
+filename     = "session_2026-03-05.log"
+sha256       = "8888f740dcce7a83cf3ac673ca03d9c4c872dbd253f707bf88659779164fe8fc"
+size_bytes   = 7553531
+date_captured = "2026-03-05"
+
+[[files]]
+filename     = "session_2026-03-06.log"
+sha256       = "b3f6dc688f5382d98e0afb199141e7b20b1856133a9f852a926a0a9a1fea4442"
+size_bytes   = 3276640
+date_captured = "2026-03-06"
+
+[[files]]
+filename     = "session_2026-03-06_b.log"
+sha256       = "418f8627ebf67d7be18e366fbe1229d7a9f4c774ce114eb1c449f70a58edee33"
+size_bytes   = 12048985
+date_captured = "2026-03-06"

--- a/tests/smoke_metadata.rs
+++ b/tests/smoke_metadata.rs
@@ -1,0 +1,238 @@
+//! Tests for smoke test metadata files (corpus manifest and baseline JSON).
+//!
+//! These tests validate that the committed data files parse correctly and
+//! maintain internal consistency. They run without access to the actual
+//! corpus — no `MANASIGHT_TEST_LOGS` needed.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+// ---------------------------------------------------------------------------
+// Manifest types
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct Manifest {
+    files: Vec<ManifestEntry>,
+}
+
+#[derive(Deserialize)]
+struct ManifestEntry {
+    filename: String,
+    sha256: String,
+    size_bytes: u64,
+    date_captured: String,
+}
+
+// ---------------------------------------------------------------------------
+// Baseline types
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct Baseline {
+    #[serde(rename = "_meta")]
+    meta: BaselineMeta,
+    files: HashMap<String, BaselineFile>,
+}
+
+#[derive(Deserialize)]
+struct BaselineMeta {
+    description: String,
+    generated_from_commit: String,
+    corpus_tag: String,
+}
+
+#[derive(Deserialize)]
+struct BaselineFile {
+    total_entries: u64,
+    parsers: HashMap<String, u64>,
+    event_types: HashMap<String, u64>,
+    unclaimed: u64,
+    double_claims: u64,
+    #[allow(dead_code)]
+    timestamp_failures: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn read_manifest() -> Result<Manifest, Box<dyn std::error::Error>> {
+    let content = std::fs::read_to_string("smoke-corpus-manifest.toml")?;
+    let manifest: Manifest = toml::from_str(&content)?;
+    Ok(manifest)
+}
+
+fn read_baseline() -> Result<Baseline, Box<dyn std::error::Error>> {
+    let content = std::fs::read_to_string("smoke-baseline.json")?;
+    let baseline: Baseline = serde_json::from_str(&content)?;
+    Ok(baseline)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_manifest_parses_valid_toml() -> TestResult {
+    let manifest = read_manifest()?;
+
+    assert!(
+        !manifest.files.is_empty(),
+        "manifest should contain at least one file entry"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_manifest_entries_have_valid_fields() -> TestResult {
+    let manifest = read_manifest()?;
+
+    for entry in &manifest.files {
+        // Filename must end in .log
+        assert!(
+            std::path::Path::new(&entry.filename)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("log")),
+            "filename '{}' should have a .log extension",
+            entry.filename
+        );
+
+        // SHA-256 must be 64 hex characters
+        assert_eq!(
+            entry.sha256.len(),
+            64,
+            "sha256 for '{}' should be 64 chars, got {}",
+            entry.filename,
+            entry.sha256.len()
+        );
+        assert!(
+            entry.sha256.chars().all(|c| c.is_ascii_hexdigit()),
+            "sha256 for '{}' should be hex-only",
+            entry.filename
+        );
+
+        // Size must be positive
+        assert!(
+            entry.size_bytes > 0,
+            "size_bytes for '{}' should be positive",
+            entry.filename
+        );
+
+        // Date must match YYYY-MM-DD format (10 chars)
+        assert_eq!(
+            entry.date_captured.len(),
+            10,
+            "date_captured for '{}' should be YYYY-MM-DD format",
+            entry.filename
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_manifest_filenames_are_unique() -> TestResult {
+    let manifest = read_manifest()?;
+
+    let mut seen = std::collections::HashSet::new();
+    for entry in &manifest.files {
+        assert!(
+            seen.insert(&entry.filename),
+            "duplicate filename in manifest: '{}'",
+            entry.filename
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_baseline_parses_valid_json() -> TestResult {
+    let baseline = read_baseline()?;
+
+    assert!(
+        !baseline.files.is_empty(),
+        "baseline should contain at least one file entry"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_baseline_entries_have_consistent_counts() -> TestResult {
+    let baseline = read_baseline()?;
+
+    for (filename, file_data) in &baseline.files {
+        // total_entries must be positive
+        assert!(
+            file_data.total_entries > 0,
+            "total_entries for '{filename}' should be positive",
+        );
+
+        // Sum of parser claims should not exceed total_entries
+        let parser_sum: u64 = file_data.parsers.values().sum();
+        assert!(
+            parser_sum <= file_data.total_entries,
+            "parser claim sum ({parser_sum}) for '{filename}' exceeds total_entries ({})",
+            file_data.total_entries
+        );
+
+        // When double_claims is 0, parser claims + unclaimed should equal total_entries
+        if file_data.double_claims == 0 {
+            let accounted = parser_sum + file_data.unclaimed;
+            assert_eq!(
+                accounted, file_data.total_entries,
+                "parser claims ({parser_sum}) + unclaimed ({}) should equal total_entries ({}) \
+                 for '{filename}' when double_claims is 0",
+                file_data.unclaimed, file_data.total_entries
+            );
+        }
+
+        // Event type counts should be non-empty when any parser claimed entries
+        if parser_sum > 0 {
+            assert!(
+                !file_data.event_types.is_empty(),
+                "event_types for '{filename}' should not be empty when parsers claimed entries",
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_manifest_and_baseline_cover_same_files() -> TestResult {
+    let manifest = read_manifest()?;
+    let baseline = read_baseline()?;
+
+    let mut manifest_files: Vec<&str> =
+        manifest.files.iter().map(|e| e.filename.as_str()).collect();
+    manifest_files.sort_unstable();
+
+    let mut baseline_files: Vec<&str> = baseline.files.keys().map(String::as_str).collect();
+    baseline_files.sort_unstable();
+
+    assert_eq!(
+        manifest_files, baseline_files,
+        "manifest and baseline should reference the same set of files"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_baseline_meta_fields_present() -> TestResult {
+    let baseline = read_baseline()?;
+
+    assert!(
+        !baseline.meta.description.is_empty(),
+        "_meta.description should not be empty"
+    );
+    assert!(
+        !baseline.meta.generated_from_commit.is_empty(),
+        "_meta.generated_from_commit should not be empty"
+    );
+    assert!(
+        !baseline.meta.corpus_tag.is_empty(),
+        "_meta.corpus_tag should not be empty"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add `smoke-corpus-manifest.toml` describing the 6 test corpus files (filename, sha256, size_bytes, date_captured)
- Add `smoke-baseline.json` with per-file, per-parser event counts from smoke tests
- Add `tests/smoke-results/` to `.gitignore`
- Add `toml` dev-dependency and 7 integration tests validating manifest/baseline structure and consistency

## Changes Made
- New file: `smoke-corpus-manifest.toml` — corpus metadata committed to the public repo
- New file: `smoke-baseline.json` — ratchet baseline for smoke test results
- New file: `tests/smoke_metadata.rs` — 7 tests validating data file parsing, field validity, cross-file consistency
- Updated: `.gitignore` — exclude smoke results directory
- Updated: `Cargo.toml` / `Cargo.lock` — add `toml` dev-dependency for manifest parsing in tests

## Testing
- 7 new integration tests in `tests/smoke_metadata.rs`:
  - `test_manifest_parses_valid_toml` — TOML parses without error
  - `test_manifest_entries_have_valid_fields` — .log extension, 64-char hex sha256, positive size, date format
  - `test_manifest_filenames_are_unique` — no duplicate filenames
  - `test_baseline_parses_valid_json` — JSON parses without error
  - `test_baseline_entries_have_consistent_counts` — parser claims + unclaimed = total_entries
  - `test_manifest_and_baseline_cover_same_files` — both files reference identical set of filenames
  - `test_baseline_meta_fields_present` — meta section has non-empty description, commit, corpus_tag
- All existing tests passing (780 unit + 7 integration + 7 doc-tests)
- Clippy clean, formatted

## Stacked PR
Base: `main` — this is the first PR in the stack.

Closes manasight/manasight-docs#238

Generated with [Claude Code](https://claude.com/claude-code)