### PR TITLE
Add Cargo.toml metadata for public crate readiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/manasight/manasight-parser"
+readme = "README.md"
+rust-version = "1.93.0"
+keywords = ["mtg-arena", "parser", "log", "magic-the-gathering"]
+categories = ["parser-implementations", "games"]
 
 [dependencies]
 base64 = "0.22"


### PR DESCRIPTION
## Summary

- Adds `readme`, `rust-version` (MSRV 1.93.0), `keywords`, and `categories` fields to `Cargo.toml`
- Completes the metadata needed for a well-prepared public crate on crates.io

Fixes manasight/manasight-docs#222

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)