### PR TITLE
Add issue templates, branch protection, and branch cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Report a bug in the parser
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages or unexpected output.
+
+## Environment
+
+- **manasight-parser version**: (e.g., 0.1.0 or commit hash)
+- **Rust version**: (output of `rustc --version`)
+- **OS**: (e.g., Windows 11, macOS 15, Ubuntu 24.04)
+- **MTG Arena version**: (if relevant)
+
+## Log Snippet
+
+If applicable, include a **sanitized** snippet from `Player.log` that triggers the issue. Remove any account IDs, usernames, or other personal information.
+
+```
+paste log snippet here
+```
+
+## Additional Context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Use Case
+
+Describe the problem you're trying to solve or the use case for this feature.
+
+## Proposed API
+
+If applicable, sketch out how you'd expect the feature to work:
+
+```rust
+// Example usage
+```
+
+## Alternatives Considered
+
+Any alternative approaches you've considered.
+
+## Additional Context
+
+Any other context, references, or screenshots.


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/` with bug report and feature request templates
- Branch protection enabled on `main` (require PR, require CI checks, require up-to-date)
- Deleted ~44 stale merged branches (remote + local) and pruned tracking refs

Fixes manasight/manasight-docs#224

## Test plan

- [x] Bug report template includes: description, steps to reproduce, environment, sanitized log snippet
- [x] Feature request template includes: use case, proposed API, alternatives
- [x] Branch protection verified via `gh api` (requires "Lint & Test" and "cargo deny" checks)
- [x] `git branch -r` shows only `main` and active dependabot branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)