### PR TITLE
Add CHANGELOG.md and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- Brief description of the changes -->
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses, e.g. Fixes #123 -->
+
+## Checklist
+
+- [ ] Tests pass: `cargo test --all-features`
+- [ ] Clippy clean: `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] Formatted: `cargo fmt --all -- --check`
+- [ ] New/updated tests for code changes
+- [ ] Documentation updated (if applicable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- **Parsers** for all Arena log event categories: session, match state, GRE (connect, game state messages, annotations), client actions, game results, bot draft, human draft, rank, inventory, collection, event lifecycle
+- **Async event bus** with broadcast fan-out for real-time event delivery
+- **File tailer** with polling-based log following
+- **Multi-platform log discovery** for Windows and macOS
+- **Timestamp parser** with Arena-specific format handling
+- **Line buffer** with log entry header detection and reassembly
+- **Performance-class router** for fast dispatch to the correct parser


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` in Keep a Changelog format with initial v0.1.0 entry summarizing all current parser capabilities
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with summary, related issue link, and CI checklist

Fixes manasight/manasight-docs#225

## Checklist

- [x] Tests pass: `cargo test --all-features`
- [x] Clippy clean: `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Formatted: `cargo fmt --all -- --check`
- [x] New/updated tests for code changes
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)