### PR TITLE
Add contribution licensing clarity to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo fmt --all
 ```
 
+## Licensing of Contributions
+
+By submitting a pull request, you agree that your contributions are licensed under the same terms as the project: [MIT](LICENSE-MIT) OR [Apache-2.0](LICENSE-APACHE), at the user's option.
+
 ## Code of Conduct
 
 This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

- Adds a "Licensing of Contributions" section to CONTRIBUTING.md clarifying that all contributions are licensed under the same MIT OR Apache-2.0 dual license as the project

This removes ambiguity about contributor IP rights, which is recommended before publishing to crates.io.

## Test plan

- [x] Verify wording matches project license (`MIT OR Apache-2.0`)
- [x] Verify links to LICENSE-MIT and LICENSE-APACHE are correct
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)