### PR TITLE
Add manasight.gg backlink to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # manasight-parser
 
+**manasight-parser** is the log parsing engine behind [Manasight](https://manasight.gg), an MTG Arena companion app.
+
 MTG Arena log file parser — a Rust library crate that reads Arena's `Player.log` and emits typed game events via an async event bus.
 
 ## Architecture


### PR DESCRIPTION
## Summary
- Adds a backlink to [manasight.gg](https://manasight.gg) near the top of the README, creating an indexable link from the GitHub page to the project domain.

## Test plan
- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm the link to manasight.gg resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)