### PR TITLE
Fix #62: duplicate GameResult and UTC timestamp on LogFileRotated

### DIFF
--- a/src/log/tailer.rs
+++ b/src/log/tailer.rs
@@ -20,7 +20,7 @@ use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 use super::entry::{LineBuffer, LogEntry};
@@ -358,7 +358,7 @@ impl FileTailer {
 
             self.last_rotation = Some(RotationInfo {
                 previous_file_size,
-                detected_at: Utc::now(),
+                detected_at: Local::now().naive_local().and_utc(),
             });
 
             ::log::info!(
@@ -1367,8 +1367,10 @@ mod tests {
             let rotation = tailer.take_rotation();
             assert!(rotation.is_some());
             if let Some(info) = rotation {
-                // detected_at should be recent (within last 5 seconds).
-                let elapsed = Utc::now() - info.detected_at();
+                // detected_at uses local-as-UTC convention (Local::now()
+                // stored as DateTime<Utc>) to match Arena's timestamp format.
+                let local_as_utc = Local::now().naive_local().and_utc();
+                let elapsed = local_as_utc - info.detected_at();
                 assert!(
                     elapsed.num_seconds() < 5,
                     "detected_at should be recent, got {elapsed}"

--- a/src/parsers/gre/game_result.rs
+++ b/src/parsers/gre/game_result.rs
@@ -11,6 +11,24 @@ pub(super) fn is_game_over(gre_msg: &serde_json::Value) -> bool {
         == Some(super::GAME_STAGE_GAME_OVER)
 }
 
+/// Match state value indicating the overall match has ended.
+const MATCH_STATE_MATCH_COMPLETE: &str = "MatchState_MatchComplete";
+
+/// Returns `true` if the GRE message has `matchState == MatchState_MatchComplete`.
+///
+/// Arena batches two `GameStage_GameOver` messages per game end:
+/// `MatchState_GameComplete` (game scope) and `MatchState_MatchComplete`
+/// (match scope). We emit only the game-complete signal to avoid duplicates
+/// and to keep consistent semantics for Bo1 and Bo3.
+pub(super) fn is_match_complete(gre_msg: &serde_json::Value) -> bool {
+    gre_msg
+        .get("gameStateMessage")
+        .and_then(|gsm| gsm.get("gameInfo"))
+        .and_then(|gi| gi.get("matchState"))
+        .and_then(serde_json::Value::as_str)
+        == Some(MATCH_STATE_MATCH_COMPLETE)
+}
+
 /// Builds a structured payload for a game result extracted from a GRE
 /// `GameStateMessage` with `GameStage_GameOver`.
 ///
@@ -165,6 +183,48 @@ mod tests {
                 }
             })
         )
+    }
+
+    mod is_match_complete_tests {
+        use crate::parsers::gre::game_result;
+
+        #[test]
+        fn test_is_match_complete_true_for_match_complete() {
+            let msg = serde_json::json!({
+                "gameStateMessage": {
+                    "gameInfo": {
+                        "stage": "GameStage_GameOver",
+                        "matchState": "MatchState_MatchComplete"
+                    }
+                }
+            });
+            assert!(game_result::is_match_complete(&msg));
+        }
+
+        #[test]
+        fn test_is_match_complete_false_for_game_complete() {
+            let msg = serde_json::json!({
+                "gameStateMessage": {
+                    "gameInfo": {
+                        "stage": "GameStage_GameOver",
+                        "matchState": "MatchState_GameComplete"
+                    }
+                }
+            });
+            assert!(!game_result::is_match_complete(&msg));
+        }
+
+        #[test]
+        fn test_is_match_complete_false_for_missing_match_state() {
+            let msg = serde_json::json!({
+                "gameStateMessage": {
+                    "gameInfo": {
+                        "stage": "GameStage_GameOver"
+                    }
+                }
+            });
+            assert!(!game_result::is_match_complete(&msg));
+        }
     }
 
     mod game_result_detection {

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -21,9 +21,12 @@
 //! structure.
 //!
 //! Most messages are Class 1 (Interactive Dispatch). The exception is when
-//! `gameInfo.stage` equals `GameStage_GameOver` — these are emitted as
+//! `gameInfo.stage` equals `GameStage_GameOver` with
+//! `matchState != MatchState_MatchComplete` — these are emitted as
 //! `GameEvent::GameResult` (Class 3, Post-Game Batch) to trigger batch
-//! assembly in downstream consumers.
+//! assembly in downstream consumers. Arena sends two `GameStage_GameOver`
+//! messages per game end (`MatchState_GameComplete` + `MatchState_MatchComplete`);
+//! only the game-complete signal is emitted to avoid duplicate results.
 //!
 //! ## `GameStateMessage` structure
 //!
@@ -153,12 +156,12 @@ pub fn try_parse(
         let msg_type = msg.get("type").and_then(serde_json::Value::as_str);
         if let Some(GAME_STATE_MESSAGE_TYPE | QUEUED_GAME_STATE_MESSAGE_TYPE) = msg_type {
             let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-            if game_result::is_game_over(msg) {
+            if game_result::is_game_over(msg) && !game_result::is_match_complete(msg) {
                 let payload = game_result::build_game_result_payload(msg);
                 events.push(GameEvent::GameResult(GameResultEvent::new(
                     metadata, payload,
                 )));
-            } else {
+            } else if !game_result::is_game_over(msg) {
                 let payload = game_state::build_game_state_message_payload(msg);
                 events.push(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
             }
@@ -221,7 +224,7 @@ fn find_message_by_type<'a>(
 mod tests {
     use super::*;
     use crate::parsers::test_helpers::{
-        game_state_payload, test_timestamp, unity_entry, EntryHeader,
+        game_result_payload, game_state_payload, test_timestamp, unity_entry, EntryHeader,
     };
     use test_fixtures::*;
 
@@ -789,6 +792,42 @@ mod tests {
             assert_eq!(results.len(), 2);
             assert!(matches!(&results[0], GameEvent::GameState(_)));
             assert!(matches!(&results[1], GameEvent::GameResult(_)));
+        }
+
+        #[test]
+        fn test_try_parse_dual_game_over_emits_single_game_result() {
+            let body = batched_dual_game_over_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            // Should emit exactly 1 GameResult (GameComplete), not 2.
+            let game_results: Vec<_> = results
+                .iter()
+                .filter(|e| matches!(e, GameEvent::GameResult(_)))
+                .collect();
+            assert_eq!(game_results.len(), 1);
+        }
+
+        #[test]
+        fn test_try_parse_dual_game_over_uses_game_complete() {
+            let body = batched_dual_game_over_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            let game_result = results
+                .iter()
+                .find(|e| matches!(e, GameEvent::GameResult(_)))
+                .unwrap_or_else(|| unreachable!());
+            let payload = game_result_payload(game_result);
+            assert_eq!(payload["match_state"], "MatchState_GameComplete");
+        }
+
+        #[test]
+        fn test_try_parse_dual_game_over_skips_match_complete_entirely() {
+            let body = batched_dual_game_over_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            // MatchComplete should not appear as GameState or GameResult.
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::GameResult(_)));
         }
 
         #[test]

--- a/src/parsers/gre/test_fixtures.rs
+++ b/src/parsers/gre/test_fixtures.rs
@@ -386,6 +386,72 @@ pub(super) fn batched_gsm_with_game_over_body() -> String {
     )
 }
 
+/// Helper: build a batched GRE event with two `GameStage_GameOver` messages:
+/// `MatchState_GameComplete` followed by `MatchState_MatchComplete`, matching
+/// the real Arena pattern where both are sent in the same batch at game end.
+pub(super) fn batched_dual_game_over_body() -> String {
+    format!(
+        "[UnityCrossThreadLogger]greToClientEvent\n{}",
+        serde_json::json!({
+            "greToClientEvent": {
+                "greToClientMessages": [
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "msgId": 50,
+                        "gameStateId": 500,
+                        "gameStateMessage": {
+                            "gameInfo": {
+                                "stage": "GameStage_GameOver",
+                                "matchState": "MatchState_GameComplete",
+                                "matchID": "match-dual-test",
+                                "gameNumber": 1,
+                                "results": [
+                                    {
+                                        "scope": "MatchScope_Game",
+                                        "result": "ResultType_WinLoss",
+                                        "winningTeamId": 1,
+                                        "reason": "ResultReason_Game"
+                                    }
+                                ]
+                            },
+                            "zones": [],
+                            "gameObjects": [],
+                            "players": [{"seatId": 1, "lifeTotal": 20}]
+                        }
+                    },
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "msgId": 51,
+                        "gameStateId": 501,
+                        "gameStateMessage": {
+                            "gameInfo": {
+                                "stage": "GameStage_GameOver",
+                                "matchState": "MatchState_MatchComplete",
+                                "matchID": "match-dual-test",
+                                "gameNumber": 1,
+                                "results": [
+                                    {
+                                        "scope": "MatchScope_Game",
+                                        "result": "ResultType_WinLoss",
+                                        "winningTeamId": 1,
+                                        "reason": "ResultReason_Game"
+                                    },
+                                    {
+                                        "scope": "MatchScope_Match",
+                                        "result": "ResultType_WinLoss",
+                                        "winningTeamId": 1,
+                                        "reason": "ResultReason_Game"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        })
+    )
+}
+
 /// Helper: build a `GameStateMessage` with an empty `gameStateMessage`
 /// (no zones, no objects, no game info).
 pub(super) fn empty_game_state_message_body() -> String {


### PR DESCRIPTION
## Summary
- **Bug 1:** Filter out `MatchState_MatchComplete` game-over messages, emitting only `MatchState_GameComplete` as a `GameResult` event. Arena batches both per game end; emitting only the game-complete signal avoids duplicate results and maintains consistent semantics for Bo1 and future Bo3.
- **Bug 2:** Replace `Utc::now()` with `Local::now().naive_local().and_utc()` for `LogFileRotated` timestamps, matching the "local-as-UTC" convention used by all Arena-parsed timestamps.

## Changes Made
- `src/parsers/gre/mod.rs`: Added `is_match_complete` check in the message loop to skip `MatchState_MatchComplete` messages; updated module doc comment
- `src/parsers/gre/game_result.rs`: Added `is_match_complete()` helper function with 3 unit tests
- `src/parsers/gre/test_fixtures.rs`: Added `batched_dual_game_over_body()` fixture matching real Arena batch pattern
- `src/log/tailer.rs`: Changed `Utc::now()` to `Local::now().naive_local().and_utc()`; updated timestamp test

## Testing
- All tests passing (837 tests)
- Linting clean, formatted
- Code coverage: 97.25% coverage, 1272/1308 lines covered
- 6 new tests: 3 for `is_match_complete` detection, 3 for duplicate game-over deduplication in batched messages

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)