### PR TITLE
Update smoke baseline for smoke-data-v4

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       # Cache the downloaded corpus tarball between runs.
-      # The key is paired with the release tag (smoke-data-v3). If the corpus
+      # The key is paired with the release tag (smoke-data-v4). If the corpus
       # is updated, bump both the release tag and this cache key together.
       - name: Cache corpus tarball
         if: steps.secrets-check.outputs.skip == 'false'
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/smoke-corpus.tar.gz
-          key: smoke-corpus-v3
+          key: smoke-corpus-v4
 
       # Download corpus from manasight-test-data GitHub Release.
       - name: Download corpus
@@ -72,7 +72,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TEST_DATA_TOKEN }}
         run: |
-          gh release download smoke-data-v3 \
+          gh release download smoke-data-v4 \
             --repo manasight/manasight-test-data \
             --pattern "*.tar.gz" \
             --output /tmp/smoke-corpus.tar.gz

--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "smoke-data-v3",
+    "corpus_tag": "smoke-data-v4",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "e4a79e318ecaf43c9b41bd06dfaf4fc732bc682a"
+    "generated_from_commit": "e29e751fffc94a192c913301e1eb64d7255655dd"
   },
   "files": {
     "session_2026-02-22_a.log": {
@@ -236,6 +236,35 @@
       "timestamp_failures": 111,
       "total_entries": 1842,
       "unclaimed": 188
+    },
+    "session_2026-03-11_2124.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 405,
+        "EventLifecycle": 2,
+        "GameResult": 2,
+        "GameState": 1093,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 2
+      },
+      "parsers": {
+        "client_actions": 405,
+        "collection": 0,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 670,
+        "inventory": 2,
+        "match_state": 2,
+        "rank": 2,
+        "session": 2
+      },
+      "timestamp_failures": 48,
+      "total_entries": 1158,
+      "unclaimed": 73
     }
   }
 }

--- a/smoke-corpus-manifest.toml
+++ b/smoke-corpus-manifest.toml
@@ -1,7 +1,7 @@
 # Smoke test corpus manifest
 #
 # Describes the Player.log files used for smoke testing. The actual logs live
-# in a private GitHub release (manasight/manasight-test-data, tag smoke-data-v3)
+# in a private GitHub release (manasight/manasight-test-data, tag smoke-data-v4)
 # to keep large binaries out of the parser repo. This manifest is committed so
 # that anyone can see what is tested and verify corpus integrity after download.
 #
@@ -57,4 +57,10 @@ date_captured = "2026-03-08"
 filename     = "session_2026-03-11_1847.log"
 sha256       = "deaca5aabac7a889e408e8a498622127bdbb2d0f461b064cf2cba39cd9d13918"
 size_bytes   = 16424517
+date_captured = "2026-03-11"
+
+[[files]]
+filename     = "session_2026-03-11_2124.log"
+sha256       = "248f70f53d47e46ab6d37fbad8ca7249e35c5418355a71ac7eac41d37912acc0"
+size_bytes   = 11460803
 date_captured = "2026-03-11"


### PR DESCRIPTION
## Summary
- Add session_2026-03-11_2124 to smoke-baseline.json after corpus upload to smoke-data-v4
- Update corpus manifest and CI workflow tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)