### PR TITLE
Wildcard .claude/commands/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ Thumbs.db
 # Smoke test results (tracked via smoke-baseline.json, not committed)
 tests/smoke-results/
 
-# Claude Code — ignore symlinked workspace commands and runtime dirs
-.claude/commands/issue-to-merge.md
-.claude/commands/sequential-issues.md
+# Claude Code — ignore workspace commands and runtime dirs
+.claude/commands/
 .claude/worktrees/


### PR DESCRIPTION
## Summary
- Replace three individual `.claude/commands/*.md` entries with a single `.claude/commands/` directory ignore
- New symlinked commands are covered automatically without editing `.gitignore`

## Test plan
- [x] Verified all files under `.claude/commands/` are symlinks (no tracked files lost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)