### PR TITLE
Fix manasight/manasight-docs#341: detect DETAILED LOGS literal string

### DIFF
--- a/src/log/entry.rs
+++ b/src/log/entry.rs
@@ -18,7 +18,7 @@ use regex::Regex;
 
 use crate::util::truncate_for_log;
 
-/// The two known log entry header prefixes in MTG Arena's `Player.log`.
+/// The known log entry header prefixes in MTG Arena's `Player.log`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EntryHeader {
@@ -27,14 +27,24 @@ pub enum EntryHeader {
     UnityCrossThreadLogger,
     /// `[Client GRE]` — used for Game Rules Engine messages.
     ClientGre,
+    /// Metadata lines that appear outside bracket-delimited entries.
+    ///
+    /// Currently covers `DETAILED LOGS: ENABLED` and `DETAILED LOGS: DISABLED`,
+    /// which Arena writes near the top of every session (typically line 24).
+    Metadata,
 }
 
 impl EntryHeader {
-    /// Returns the bracket-enclosed header string as it appears in the log.
+    /// Returns the header string as it appears in the log.
+    ///
+    /// Bracket-delimited headers return the full `[...]` prefix.
+    /// `Metadata` returns `"METADATA"` as a synthetic label (metadata
+    /// lines have no bracket prefix in the actual log).
     pub fn as_str(self) -> &'static str {
         match self {
             Self::UnityCrossThreadLogger => "[UnityCrossThreadLogger]",
             Self::ClientGre => "[Client GRE]",
+            Self::Metadata => "METADATA",
         }
     }
 }
@@ -124,10 +134,36 @@ impl LineBuffer {
     /// line is a continuation of the current entry, or when no entry was
     /// in progress (buffer was empty).
     ///
+    /// Metadata lines (`DETAILED LOGS: ENABLED` / `DISABLED`) are treated
+    /// as self-contained entries: the current in-progress entry (if any) is
+    /// flushed, the metadata entry is returned, and no new accumulation
+    /// begins. If a metadata line is the first line in the stream (nothing
+    /// to flush), it is returned directly.
+    ///
     /// Lines that arrive before any header has been seen are discarded with
     /// a warning log — this handles partial entries at the start of a file
     /// or after rotation.
     pub fn push_line(&mut self, line: &str) -> Option<LogEntry> {
+        // Check for metadata lines first — these are self-contained.
+        if Self::is_metadata_line(line) {
+            let flushed = self.take_entry();
+            let metadata_entry = LogEntry {
+                header: EntryHeader::Metadata,
+                body: line.to_owned(),
+            };
+            // If there was a buffered entry, return it now.
+            // The metadata entry needs to be emitted too, so we buffer it
+            // as a complete single-line entry that will flush on the next
+            // header or explicit flush.
+            if flushed.is_some() {
+                self.current_header = Some(EntryHeader::Metadata);
+                self.lines.push(line.to_owned());
+                return flushed;
+            }
+            // No prior entry — return the metadata entry directly.
+            return Some(metadata_entry);
+        }
+
         if let Some(header) = self.detect_header(line) {
             let flushed = self.take_entry();
             self.current_header = Some(header);
@@ -167,6 +203,16 @@ impl LineBuffer {
     /// Returns `true` if no entry is currently being accumulated.
     pub fn is_empty(&self) -> bool {
         self.current_header.is_none()
+    }
+
+    /// Returns `true` if the line is a metadata line that should be
+    /// treated as a self-contained entry.
+    ///
+    /// Currently matches `DETAILED LOGS: ENABLED` and
+    /// `DETAILED LOGS: DISABLED`.
+    fn is_metadata_line(line: &str) -> bool {
+        let trimmed = line.trim();
+        trimmed == "DETAILED LOGS: ENABLED" || trimmed == "DETAILED LOGS: DISABLED"
     }
 
     /// Detects whether `line` starts with a known header prefix.
@@ -628,6 +674,122 @@ mod tests {
                 assert_eq!(e.header, EntryHeader::UnityCrossThreadLogger);
                 assert_eq!(e.body, format!("[UnityCrossThreadLogger] Event{i}"));
             }
+        }
+    }
+
+    // -- Metadata line detection -----------------------------------------------
+
+    mod metadata_lines {
+        use super::*;
+
+        #[test]
+        fn test_push_line_detailed_logs_enabled_as_first_line() {
+            let mut buf = LineBuffer::new();
+            let result = buf.push_line("DETAILED LOGS: ENABLED");
+
+            assert_eq!(
+                result,
+                Some(expected(EntryHeader::Metadata, "DETAILED LOGS: ENABLED")),
+            );
+            // Buffer should be empty after — metadata is self-contained.
+            assert!(buf.is_empty());
+        }
+
+        #[test]
+        fn test_push_line_detailed_logs_disabled_as_first_line() {
+            let mut buf = LineBuffer::new();
+            let result = buf.push_line("DETAILED LOGS: DISABLED");
+
+            assert_eq!(
+                result,
+                Some(expected(EntryHeader::Metadata, "DETAILED LOGS: DISABLED")),
+            );
+        }
+
+        #[test]
+        fn test_push_line_metadata_flushes_buffered_entry() {
+            let mut buf = LineBuffer::new();
+            buf.push_line("[UnityCrossThreadLogger] Event1");
+
+            // Metadata line should flush the buffered entry.
+            let flushed = buf.push_line("DETAILED LOGS: ENABLED");
+            assert_eq!(
+                flushed,
+                Some(expected(
+                    EntryHeader::UnityCrossThreadLogger,
+                    "[UnityCrossThreadLogger] Event1",
+                )),
+            );
+
+            // The metadata entry should be available on next flush.
+            let metadata = buf.flush();
+            assert_eq!(
+                metadata,
+                Some(expected(EntryHeader::Metadata, "DETAILED LOGS: ENABLED")),
+            );
+        }
+
+        #[test]
+        fn test_push_line_metadata_then_header_flushes_metadata() {
+            let mut buf = LineBuffer::new();
+            buf.push_line("DETAILED LOGS: ENABLED");
+
+            // Next header should work normally (nothing to flush since
+            // the metadata entry was returned immediately).
+            assert!(buf.push_line("[UnityCrossThreadLogger] Event").is_none());
+            assert_eq!(
+                buf.flush(),
+                Some(expected(
+                    EntryHeader::UnityCrossThreadLogger,
+                    "[UnityCrossThreadLogger] Event",
+                )),
+            );
+        }
+
+        #[test]
+        fn test_push_line_metadata_buffered_then_next_header_flushes() {
+            let mut buf = LineBuffer::new();
+            buf.push_line("[UnityCrossThreadLogger] Event1");
+
+            // Metadata line flushes Event1, buffers itself.
+            buf.push_line("DETAILED LOGS: DISABLED");
+
+            // Next header flushes the metadata entry.
+            let flushed = buf.push_line("[UnityCrossThreadLogger] Event2");
+            assert_eq!(
+                flushed,
+                Some(expected(EntryHeader::Metadata, "DETAILED LOGS: DISABLED")),
+            );
+        }
+
+        #[test]
+        fn test_push_line_metadata_similar_text_not_matched() {
+            let mut buf = LineBuffer::new();
+            // Similar but not exact — should be treated as headerless.
+            assert!(buf.push_line("DETAILED LOGS: UNKNOWN").is_none());
+            assert!(buf.push_line("detailed logs: enabled").is_none());
+            assert!(buf.push_line("DETAILED LOGS:ENABLED").is_none());
+        }
+
+        #[test]
+        fn test_push_line_metadata_with_leading_trailing_whitespace() {
+            let mut buf = LineBuffer::new();
+            // Whitespace around the exact text should still match.
+            let result = buf.push_line("  DETAILED LOGS: ENABLED  ");
+            assert!(result.is_some());
+            if let Some(entry) = result {
+                assert_eq!(entry.header, EntryHeader::Metadata);
+            }
+        }
+
+        #[test]
+        fn test_entry_header_metadata_as_str() {
+            assert_eq!(EntryHeader::Metadata.as_str(), "METADATA");
+        }
+
+        #[test]
+        fn test_entry_header_metadata_display() {
+            assert_eq!(EntryHeader::Metadata.to_string(), "METADATA");
         }
     }
 }

--- a/src/parsers/metadata.rs
+++ b/src/parsers/metadata.rs
@@ -1,0 +1,180 @@
+//! Metadata event parser: `DETAILED LOGS` status detection.
+//!
+//! Recognizes the `DETAILED LOGS: ENABLED` and `DETAILED LOGS: DISABLED`
+//! lines that Arena writes near the top of every session (typically line 24
+//! of `Player.log`). These lines have no bracket header prefix and are
+//! recognized by [`LineBuffer`] as [`EntryHeader::Metadata`] entries.
+//!
+//! [`LineBuffer`]: crate::log::entry::LineBuffer
+//! [`EntryHeader::Metadata`]: crate::log::entry::EntryHeader::Metadata
+
+use crate::events::{DetailedLoggingStatusEvent, EventMetadata, GameEvent};
+use crate::log::entry::{EntryHeader, LogEntry};
+
+/// Marker text for enabled detailed logging.
+const DETAILED_LOGS_ENABLED: &str = "DETAILED LOGS: ENABLED";
+
+/// Marker text for disabled detailed logging.
+const DETAILED_LOGS_DISABLED: &str = "DETAILED LOGS: DISABLED";
+
+/// Attempts to parse a [`LogEntry`] as a metadata event.
+///
+/// Returns `Some(GameEvent::DetailedLoggingStatus(_))` if the entry is a
+/// `DETAILED LOGS` metadata line, or `None` otherwise.
+///
+/// The `timestamp` is `None` because metadata lines do not carry a
+/// timestamp in the log. It is passed through to [`EventMetadata`] so
+/// downstream consumers can distinguish real vs missing timestamps.
+pub fn try_parse(
+    entry: &LogEntry,
+    timestamp: Option<chrono::DateTime<chrono::Utc>>,
+) -> Option<GameEvent> {
+    if entry.header != EntryHeader::Metadata {
+        return None;
+    }
+
+    let trimmed = entry.body.trim();
+
+    let enabled = if trimmed == DETAILED_LOGS_ENABLED {
+        true
+    } else if trimmed == DETAILED_LOGS_DISABLED {
+        false
+    } else {
+        return None;
+    };
+
+    let metadata = EventMetadata::new(timestamp, entry.body.as_bytes().to_vec());
+    Some(GameEvent::DetailedLoggingStatus(
+        DetailedLoggingStatusEvent::new(metadata, serde_json::json!({ "enabled": enabled })),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parsers::test_helpers::test_timestamp;
+
+    /// Helper: build a metadata `LogEntry` from body text.
+    fn metadata_entry(body: &str) -> LogEntry {
+        LogEntry {
+            header: EntryHeader::Metadata,
+            body: body.to_owned(),
+        }
+    }
+
+    // -- Detailed logs detection -----------------------------------------------
+
+    mod detailed_logs {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_detailed_logs_enabled() {
+            let entry = metadata_entry("DETAILED LOGS: ENABLED");
+            let result = try_parse(&entry, None);
+
+            assert!(result.is_some());
+            assert!(
+                matches!(
+                    &result,
+                    Some(GameEvent::DetailedLoggingStatus(e)) if e.enabled() == Some(true)
+                ),
+                "expected DetailedLoggingStatus(enabled=true), got {result:?}"
+            );
+        }
+
+        #[test]
+        fn test_try_parse_detailed_logs_disabled() {
+            let entry = metadata_entry("DETAILED LOGS: DISABLED");
+            let result = try_parse(&entry, None);
+
+            assert!(result.is_some());
+            assert!(
+                matches!(
+                    &result,
+                    Some(GameEvent::DetailedLoggingStatus(e)) if e.enabled() == Some(false)
+                ),
+                "expected DetailedLoggingStatus(enabled=false), got {result:?}"
+            );
+        }
+
+        #[test]
+        fn test_try_parse_preserves_raw_bytes() {
+            let entry = metadata_entry("DETAILED LOGS: ENABLED");
+            let result = try_parse(&entry, None);
+
+            assert!(result.is_some());
+            if let Some(ref event) = result {
+                assert_eq!(event.metadata().raw_bytes(), b"DETAILED LOGS: ENABLED");
+            }
+        }
+
+        #[test]
+        fn test_try_parse_passes_through_timestamp() {
+            let ts = Some(test_timestamp());
+            let entry = metadata_entry("DETAILED LOGS: ENABLED");
+            let result = try_parse(&entry, ts);
+
+            assert!(result.is_some());
+            if let Some(ref event) = result {
+                assert_eq!(event.metadata().timestamp(), ts);
+            }
+        }
+
+        #[test]
+        fn test_try_parse_none_timestamp() {
+            let entry = metadata_entry("DETAILED LOGS: DISABLED");
+            let result = try_parse(&entry, None);
+
+            assert!(result.is_some());
+            if let Some(ref event) = result {
+                assert!(event.metadata().timestamp().is_none());
+            }
+        }
+    }
+
+    // -- Non-matching entries -------------------------------------------------
+
+    mod non_matching {
+        use super::*;
+
+        #[test]
+        fn test_try_parse_unrelated_metadata_returns_none() {
+            let entry = metadata_entry("some other metadata line");
+            assert!(try_parse(&entry, None).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_unity_header_returns_none() {
+            let entry = LogEntry {
+                header: EntryHeader::UnityCrossThreadLogger,
+                body: "DETAILED LOGS: ENABLED".to_owned(),
+            };
+            assert!(try_parse(&entry, None).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_client_gre_header_returns_none() {
+            let entry = LogEntry {
+                header: EntryHeader::ClientGre,
+                body: "DETAILED LOGS: ENABLED".to_owned(),
+            };
+            assert!(try_parse(&entry, None).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_similar_text_returns_none() {
+            let entry = metadata_entry("DETAILED LOGS: UNKNOWN");
+            assert!(try_parse(&entry, None).is_none());
+        }
+
+        #[test]
+        fn test_try_parse_empty_body_returns_none() {
+            let entry = metadata_entry("");
+            assert!(try_parse(&entry, None).is_none());
+        }
+    }
+}

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -8,6 +8,7 @@ pub mod event_lifecycle;
 pub mod gre;
 pub mod inventory;
 pub mod match_state;
+pub mod metadata;
 pub mod rank;
 pub mod session;
 #[cfg(test)]

--- a/src/router.rs
+++ b/src/router.rs
@@ -227,6 +227,7 @@ fn extract_timestamp(body: &str) -> Option<DateTime<Utc>> {
 /// Parsers are tried in order of expected frequency during typical
 /// gameplay to minimize unnecessary parse attempts:
 ///
+/// 0. Metadata — `DETAILED LOGS` status (header-type short-circuit)
 /// 1. GRE messages (game state + game result) — most frequent in-game
 /// 2. Client actions — frequent player decisions
 /// 3. Match state — match boundaries
@@ -246,6 +247,11 @@ fn extract_timestamp(body: &str) -> Option<DateTime<Utc>> {
 /// `timestamp` is `None` when the log entry header did not contain a
 /// parseable timestamp; parsers pass it through to `EventMetadata`.
 fn dispatch_to_parsers(entry: &LogEntry, timestamp: Option<DateTime<Utc>>) -> Vec<GameEvent> {
+    // Metadata entries are routed directly to the metadata parser.
+    if let Some(event) = parsers::metadata::try_parse(entry, timestamp) {
+        return vec![event];
+    }
+
     // GRE parser returns Vec<GameEvent> (may contain multiple batched GSMs).
     let gre_events = parsers::gre::try_parse(entry, timestamp);
     if !gre_events.is_empty() {
@@ -830,6 +836,70 @@ mod tests {
             let results = router.route(&entry);
             assert_eq!(results.len(), 1);
             assert!(matches!(&results[0], GameEvent::GameState(_)));
+        }
+    }
+
+    // -- Router: Metadata header entries --------------------------------------
+
+    mod metadata_entries {
+        use super::*;
+
+        /// Helper: build a `LogEntry` with `Metadata` header.
+        fn metadata_entry(body: &str) -> LogEntry {
+            LogEntry {
+                header: EntryHeader::Metadata,
+                body: body.to_owned(),
+            }
+        }
+
+        #[test]
+        fn test_route_detailed_logs_enabled() {
+            let router = Router::new();
+            let entry = metadata_entry("DETAILED LOGS: ENABLED");
+
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::DetailedLoggingStatus(_)));
+            if let GameEvent::DetailedLoggingStatus(ref e) = results[0] {
+                assert_eq!(e.enabled(), Some(true));
+            }
+            assert_eq!(router.stats().routed_count(), 1);
+        }
+
+        #[test]
+        fn test_route_detailed_logs_disabled() {
+            let router = Router::new();
+            let entry = metadata_entry("DETAILED LOGS: DISABLED");
+
+            let results = router.route(&entry);
+            assert_eq!(results.len(), 1);
+            assert!(matches!(&results[0], GameEvent::DetailedLoggingStatus(_)));
+            if let GameEvent::DetailedLoggingStatus(ref e) = results[0] {
+                assert_eq!(e.enabled(), Some(false));
+            }
+        }
+
+        #[test]
+        fn test_route_metadata_no_timestamp_failure() {
+            let router = Router::new();
+            let entry = metadata_entry("DETAILED LOGS: ENABLED");
+
+            router.route(&entry);
+            // Metadata entries have no bracket prefix for timestamp extraction,
+            // so they increment the timestamp failure counter.
+            assert_eq!(router.stats().timestamp_failure_count(), 1);
+            // But they should still be routed successfully.
+            assert_eq!(router.stats().routed_count(), 1);
+        }
+
+        #[test]
+        fn test_route_unrecognized_metadata_returns_empty() {
+            let router = Router::new();
+            let entry = metadata_entry("SOME OTHER METADATA");
+
+            let results = router.route(&entry);
+            assert!(results.is_empty());
+            assert_eq!(router.stats().unknown_count(), 1);
         }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -32,6 +32,7 @@ use std::path::Path;
 
 use crate::event_bus::{EventBus, Subscriber};
 use crate::events::{DetailedLoggingStatusEvent, GameEvent, LogFileRotatedEvent};
+use crate::log::entry::EntryHeader;
 use crate::log::tailer::{FileTailer, TailerError};
 use crate::router::Router;
 
@@ -208,16 +209,28 @@ impl std::fmt::Debug for MtgaEventStream {
 /// Tracks whether structured log headers have been observed.
 ///
 /// Used by [`run_tailer`] to detect when Arena's "Detailed Logs (Plugin
-/// Support)" setting is disabled. The 30-second timer starts on the first
-/// non-empty read (not on tailer open) to avoid false positives when Arena
-/// hasn't launched yet.
+/// Support)" setting is disabled. Detection uses two complementary signals:
+///
+/// 1. **Literal detection** (primary): `DETAILED LOGS: ENABLED/DISABLED`
+///    lines near the top of `Player.log`. When a literal signal fires,
+///    the timeout is suppressed to avoid duplicate events.
+///
+/// 2. **Timeout detection** (fallback): if 30 seconds of log writes pass
+///    without any `[UnityCrossThreadLogger]` / `[Client GRE]` headers,
+///    emits `enabled: false`. Only fires when literal detection has not
+///    already handled the status.
 struct HeaderDetectionState {
     /// When the tailer first read non-zero bytes from the log file.
     first_bytes_at: Option<tokio::time::Instant>,
     /// Whether any structured log entry has been produced.
     headers_seen: bool,
-    /// Whether the `enabled: false` event has been emitted.
+    /// Whether the `enabled: false` event has been emitted (by timeout).
     disabled_emitted: bool,
+    /// Whether a literal `DETAILED LOGS:` line has been seen.
+    ///
+    /// When `true`, the timeout path is suppressed — the literal signal
+    /// is authoritative and sufficient.
+    literal_detected: bool,
 }
 
 impl HeaderDetectionState {
@@ -226,6 +239,7 @@ impl HeaderDetectionState {
             first_bytes_at: None,
             headers_seen: false,
             disabled_emitted: false,
+            literal_detected: false,
         }
     }
 
@@ -234,6 +248,7 @@ impl HeaderDetectionState {
         self.first_bytes_at = None;
         self.headers_seen = false;
         self.disabled_emitted = false;
+        self.literal_detected = false;
     }
 
     /// Records that the tailer read bytes. Called on every poll that
@@ -249,10 +264,18 @@ impl HeaderDetectionState {
         self.headers_seen = true;
     }
 
+    /// Records that a literal `DETAILED LOGS:` line was detected.
+    ///
+    /// This suppresses the timeout fallback for the rest of this log
+    /// file session.
+    fn record_literal_detected(&mut self) {
+        self.literal_detected = true;
+    }
+
     /// Checks the current state and returns an event to emit, if any.
     ///
     /// - Returns `Some(enabled: false)` if the timeout has elapsed without
-    ///   headers (emitted once).
+    ///   headers (emitted once, suppressed if literal detection already fired).
     /// - Returns `Some(enabled: true)` if headers are seen after a
     ///   previous `enabled: false` was emitted.
     /// - Returns `None` otherwise.
@@ -264,6 +287,11 @@ impl HeaderDetectionState {
         }
 
         if self.headers_seen || self.disabled_emitted {
+            return None;
+        }
+
+        // Skip timeout when literal detection already handled it.
+        if self.literal_detected {
             return None;
         }
 
@@ -332,12 +360,25 @@ async fn run_tailer(
                             header_state.record_bytes_read();
                         }
 
-                        if !entries.is_empty() {
+                        // Check entries for metadata (literal DETAILED LOGS
+                        // detection) and structured headers.
+                        let has_structured = entries
+                            .iter()
+                            .any(|e| e.header != EntryHeader::Metadata);
+                        let has_metadata = entries
+                            .iter()
+                            .any(|e| e.header == EntryHeader::Metadata);
+
+                        if has_structured {
                             header_state.record_headers_seen();
+                        }
+                        if has_metadata {
+                            header_state.record_literal_detected();
                         }
 
                         // Check if a detailed logging status event should
-                        // be emitted.
+                        // be emitted (timeout fallback, suppressed when
+                        // literal detection already fired).
                         if let Some(enabled) = header_state.check() {
                             let event = GameEvent::DetailedLoggingStatus(
                                 DetailedLoggingStatusEvent::new_status(
@@ -857,6 +898,45 @@ mod tests {
         assert_eq!(state.check(), Some(false));
     }
 
+    // -- HeaderDetectionState: literal detection suppresses timeout -----------
+
+    #[tokio::test]
+    async fn test_header_detection_literal_suppresses_timeout() {
+        tokio::time::pause();
+        let mut state = HeaderDetectionState::new();
+        state.record_bytes_read();
+        state.record_literal_detected();
+
+        // Even after timeout, should not emit disabled — literal already handled it.
+        tokio::time::advance(std::time::Duration::from_secs(31)).await;
+        assert!(state.check().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_header_detection_literal_before_bytes() {
+        tokio::time::pause();
+        let mut state = HeaderDetectionState::new();
+        state.record_literal_detected();
+        state.record_bytes_read();
+
+        tokio::time::advance(std::time::Duration::from_secs(31)).await;
+        assert!(state.check().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_header_detection_literal_reset_clears() {
+        tokio::time::pause();
+        let mut state = HeaderDetectionState::new();
+        state.record_literal_detected();
+
+        state.reset();
+
+        // After reset, literal_detected is cleared.
+        state.record_bytes_read();
+        tokio::time::advance(std::time::Duration::from_secs(31)).await;
+        assert_eq!(state.check(), Some(false));
+    }
+
     // -- Detailed logging integration (start) ---------------------------------
 
     #[tokio::test]
@@ -897,6 +977,89 @@ mod tests {
         );
 
         stream.shutdown();
+        Ok(())
+    }
+
+    // -- Literal DETAILED LOGS detection (start_once) --------------------------
+
+    #[tokio::test]
+    async fn test_start_once_detailed_logs_enabled() -> TestResult {
+        let content = "DETAILED LOGS: ENABLED\n\
+                        [UnityCrossThreadLogger]Updated account. \
+                        DisplayName:TestPlayer, \
+                        AccountID:abc123, \
+                        Token:sometoken\n\
+                        [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
+                        some filler\n";
+        let f = temp_log(content)?;
+
+        let (_stream, mut sub) = MtgaEventStream::start_once(f.path()).await?;
+
+        // Collect all events.
+        let mut events = Vec::new();
+        loop {
+            let result =
+                tokio::time::timeout(std::time::Duration::from_secs(3), sub.recv()).await?;
+            match result {
+                Some(e) => events.push(e),
+                None => break,
+            }
+        }
+
+        // Should have a DetailedLoggingStatus(enabled=true) event.
+        let dls_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, GameEvent::DetailedLoggingStatus(_)))
+            .collect();
+        assert_eq!(
+            dls_events.len(),
+            1,
+            "expected exactly one DetailedLoggingStatus event, got {}",
+            dls_events.len(),
+        );
+        if let GameEvent::DetailedLoggingStatus(ref e) = dls_events[0] {
+            assert_eq!(e.enabled(), Some(true));
+        }
+
+        // Should also have Session event.
+        assert!(events.iter().any(|e| matches!(e, GameEvent::Session(_))));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_start_once_detailed_logs_disabled() -> TestResult {
+        let content = "DETAILED LOGS: DISABLED\n\
+                        some unstructured line\n\
+                        another unstructured line\n";
+        let f = temp_log(content)?;
+
+        let (_stream, mut sub) = MtgaEventStream::start_once(f.path()).await?;
+
+        // Collect all events.
+        let mut events = Vec::new();
+        loop {
+            let result =
+                tokio::time::timeout(std::time::Duration::from_secs(3), sub.recv()).await?;
+            match result {
+                Some(e) => events.push(e),
+                None => break,
+            }
+        }
+
+        // Should have a DetailedLoggingStatus(enabled=false) event.
+        let dls_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, GameEvent::DetailedLoggingStatus(_)))
+            .collect();
+        assert_eq!(
+            dls_events.len(),
+            1,
+            "expected exactly one DetailedLoggingStatus event, got {}",
+            dls_events.len(),
+        );
+        if let GameEvent::DetailedLoggingStatus(ref e) = dls_events[0] {
+            assert_eq!(e.enabled(), Some(false));
+        }
         Ok(())
     }
 }

--- a/tests/smoke_common/mod.rs
+++ b/tests/smoke_common/mod.rs
@@ -81,6 +81,10 @@ pub struct ParserStats {
 pub fn all_parsers() -> Vec<NamedParser> {
     vec![
         NamedParser {
+            name: "metadata",
+            func: ParserFunc::Single(parsers::metadata::try_parse),
+        },
+        NamedParser {
             name: "session",
             func: ParserFunc::Single(parsers::session::try_parse),
         },
@@ -146,6 +150,8 @@ pub fn event_type_name(event: &GameEvent) -> &'static str {
         GameEvent::Collection(_) => "Collection",
         GameEvent::Inventory(_) => "Inventory",
         GameEvent::GameResult(_) => "GameResult",
+        GameEvent::LogFileRotated(_) => "LogFileRotated",
+        GameEvent::DetailedLoggingStatus(_) => "DetailedLoggingStatus",
         // `GameEvent` is `#[non_exhaustive]`; this branch keeps the compiler
         // happy if new variants are added before this match is updated.
         _ => "Unknown",

--- a/tests/stream_integration.rs
+++ b/tests/stream_integration.rs
@@ -208,6 +208,56 @@ async fn test_stream_subscriber_ends_after_shutdown() -> TestResult {
 }
 
 #[tokio::test]
+async fn test_stream_detailed_logs_enabled_event() -> TestResult {
+    let content = "DETAILED LOGS: ENABLED\n\
+                    [UnityCrossThreadLogger]Updated account. \
+                    DisplayName:TestPlayer, \
+                    AccountID:abc123, \
+                    Token:sometoken\n\
+                    [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\nfiller\n";
+    let f = temp_log(content)?;
+
+    let (stream, mut sub) = MtgaEventStream::start(f.path()).await?;
+
+    // The first event should be DetailedLoggingStatus(enabled=true).
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), sub.recv()).await?;
+    assert!(event.is_some(), "expected an event, got None");
+    assert!(
+        matches!(&event, Some(GameEvent::DetailedLoggingStatus(_))),
+        "expected DetailedLoggingStatus event, got {event:?}"
+    );
+    if let Some(GameEvent::DetailedLoggingStatus(ref e)) = event {
+        assert_eq!(e.enabled(), Some(true));
+    }
+
+    stream.shutdown();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stream_detailed_logs_disabled_event() -> TestResult {
+    let content = "DETAILED LOGS: DISABLED\n\
+                    some unstructured line\n";
+    let f = temp_log(content)?;
+
+    let (stream, mut sub) = MtgaEventStream::start(f.path()).await?;
+
+    // The first event should be DetailedLoggingStatus(enabled=false).
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), sub.recv()).await?;
+    assert!(event.is_some(), "expected an event, got None");
+    assert!(
+        matches!(&event, Some(GameEvent::DetailedLoggingStatus(_))),
+        "expected DetailedLoggingStatus event, got {event:?}"
+    );
+    if let Some(GameEvent::DetailedLoggingStatus(ref e)) = event {
+        assert_eq!(e.enabled(), Some(false));
+    }
+
+    stream.shutdown();
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_stream_re_exports_accessible() -> TestResult {
     // Verify that key types are accessible via the crate root re-exports.
     // Using them in type annotations proves the re-exports compile.


### PR DESCRIPTION
## Summary
- Add primary detection of Arena's `DETAILED LOGS: ENABLED/DISABLED` literal strings that appear near the top of every `Player.log` session
- New `EntryHeader::Metadata` variant routes these non-bracket lines through the full pipeline
- New `parsers::metadata` module claims metadata entries and produces `DetailedLoggingStatusEvent`
- Timeout detection (#338) becomes fallback -- `HeaderDetectionState.literal_detected` flag suppresses duplicate events when literal detection fires first

## Changes Made
- `src/log/entry.rs`: Add `EntryHeader::Metadata` variant; `LineBuffer::push_line()` recognizes `DETAILED LOGS: ENABLED/DISABLED` as self-contained entries (flush-and-emit semantics); `is_metadata_line()` helper; unit tests for all metadata scenarios
- `src/parsers/metadata.rs` (new): Parser for `Metadata` header entries, produces `DetailedLoggingStatusEvent` with `enabled` flag; unit tests
- `src/parsers/mod.rs`: Register `metadata` module
- `src/router.rs`: Dispatch `Metadata` entries to metadata parser first (before GRE/other parsers); router unit tests
- `src/stream.rs`: Add `literal_detected` field to `HeaderDetectionState`; `record_literal_detected()` method; `check()` skips timeout when literal already fired; `run_tailer` detects metadata entries and updates state; integration tests for `start_once` with `DETAILED LOGS` lines; unit tests for literal-suppresses-timeout
- `tests/stream_integration.rs`: Integration tests for `DETAILED LOGS: ENABLED` and `DISABLED` through the full `MtgaEventStream::start` pipeline
- `tests/smoke_common/mod.rs`: Register metadata parser in `all_parsers()`; add `DetailedLoggingStatus` and `LogFileRotated` to `event_type_name()`

## Testing
- All tests passing (845 unit + 9 integration + 7 doc tests)
- Linting clean, formatted
- Code coverage: 97.67% (+0.35%)

## Stacked PR
Base: `main` -- merge in order after earlier PRs.

Closes manasight/manasight-docs#341

🤖 Generated with [Claude Code](https://claude.com/claude-code)