### PR TITLE
Fix manasight/manasight-docs#342: smoke test coverage for detailed logging

### DIFF
--- a/tests/stream_integration.rs
+++ b/tests/stream_integration.rs
@@ -257,6 +257,142 @@ async fn test_stream_detailed_logs_disabled_event() -> TestResult {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Detailed logging: timeout detection via run_tailer (deterministic time)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_stream_detailed_logging_timeout_fires_without_headers() -> TestResult {
+    // Verifies that run_tailer's 30-second timeout fires when a log file
+    // contains bytes but no structured headers (`[UnityCrossThreadLogger]`
+    // or `[Client GRE]`). This simulates a Player.log written with
+    // detailed logging disabled and WITHOUT the `DETAILED LOGS:` literal
+    // (pre-#341 log files, or edge cases where the literal is absent).
+    //
+    // Uses tokio::time::pause() + advance() for deterministic timing.
+    tokio::time::pause();
+
+    // Log content with NO structured headers and NO `DETAILED LOGS:` literal.
+    let content = "some unstructured line without a header\n\
+                   another line of unstructured content\n\
+                   yet another line that has no bracket prefix\n";
+    let f = temp_log(content)?;
+
+    let (stream, mut sub) = MtgaEventStream::start(f.path()).await?;
+
+    // Let the tailer's first poll tick fire and read the file content.
+    // With paused time, `tokio::time::sleep` yields to other tasks.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Advance time past the 30-second timeout threshold.
+    tokio::time::advance(std::time::Duration::from_secs(31)).await;
+
+    // Let the tailer's next poll tick fire after the advance.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Collect events within a short window after the timeout.
+    let mut events = Vec::new();
+    loop {
+        let result = tokio::time::timeout(std::time::Duration::from_millis(200), sub.recv()).await;
+        match result {
+            Ok(Some(e)) => events.push(e),
+            _ => break,
+        }
+    }
+
+    // Should have a DetailedLoggingStatus(enabled=false) from timeout.
+    let dls_events: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, GameEvent::DetailedLoggingStatus(_)))
+        .collect();
+    assert!(
+        !dls_events.is_empty(),
+        "expected DetailedLoggingStatus event from timeout, got events: {events:?}"
+    );
+    if let GameEvent::DetailedLoggingStatus(ref e) = dls_events[0] {
+        assert_eq!(
+            e.enabled(),
+            Some(false),
+            "timeout should emit enabled=false"
+        );
+    }
+
+    stream.shutdown();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stream_literal_detection_suppresses_timeout() -> TestResult {
+    // Verifies that when the `DETAILED LOGS: ENABLED` literal is present
+    // at the top of the log file (with structured headers following),
+    // only ONE DetailedLoggingStatus event is emitted — from the literal
+    // detection — and the 30-second timeout does NOT produce a duplicate.
+    //
+    // Uses tokio::time::pause() + advance() for deterministic timing.
+    tokio::time::pause();
+
+    let content = "DETAILED LOGS: ENABLED\n\
+                   [UnityCrossThreadLogger]Updated account. \
+                   DisplayName:TestPlayer, \
+                   AccountID:abc123, \
+                   Token:sometoken\n\
+                   [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\nfiller\n";
+    let f = temp_log(content)?;
+
+    let (stream, mut sub) = MtgaEventStream::start(f.path()).await?;
+
+    // Let the tailer's first poll tick fire and read the file content.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Advance time well past the 30-second timeout threshold.
+    tokio::time::advance(std::time::Duration::from_secs(35)).await;
+
+    // Let the tailer's next poll tick fire after the advance.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Collect all events within a short window.
+    let mut events = Vec::new();
+    loop {
+        let result = tokio::time::timeout(std::time::Duration::from_millis(200), sub.recv()).await;
+        match result {
+            Ok(Some(e)) => events.push(e),
+            _ => break,
+        }
+    }
+
+    // Count DetailedLoggingStatus events.
+    let dls_events: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, GameEvent::DetailedLoggingStatus(_)))
+        .collect();
+
+    assert_eq!(
+        dls_events.len(),
+        1,
+        "expected exactly ONE DetailedLoggingStatus event (from literal detection, \
+         timeout should be suppressed), got {}: {dls_events:?}",
+        dls_events.len(),
+    );
+
+    // The single event should be enabled=true (from the literal).
+    if let GameEvent::DetailedLoggingStatus(ref e) = dls_events[0] {
+        assert_eq!(
+            e.enabled(),
+            Some(true),
+            "the single event should be enabled=true from literal detection"
+        );
+    }
+
+    // Should also have other expected events (Session from the account line).
+    assert!(
+        events.iter().any(|e| matches!(e, GameEvent::Session(_))),
+        "expected Session event alongside DetailedLoggingStatus"
+    );
+
+    stream.shutdown();
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_stream_re_exports_accessible() -> TestResult {
     // Verify that key types are accessible via the crate root re-exports.


### PR DESCRIPTION
## Summary
- Add integration test verifying timeout fires after 30s with no structured headers
- Add integration test verifying literal detection suppresses duplicate timeout event
- Tests use deterministic time control (`tokio::time::pause`/`advance`)
- Tests exercise the full async pipeline via `MtgaEventStream::start()`

## Changes Made
- `tests/stream_integration.rs`: Added two new integration tests:
  - `test_stream_detailed_logging_timeout_fires_without_headers` — feeds unstructured content (no headers, no `DETAILED LOGS:` literal), advances Tokio time past 30s, asserts `DetailedLoggingStatus(enabled=false)` is emitted
  - `test_stream_literal_detection_suppresses_timeout` — feeds content with `DETAILED LOGS: ENABLED` plus structured headers, advances time past 30s, asserts exactly ONE `DetailedLoggingStatus(enabled=true)` event (no duplicate from timeout)

## Testing
- All 886 tests passing (845 unit + 41 integration/smoke/doc)
- Linting clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- Formatted (`cargo fmt --all -- --check`)
- Code coverage: 97.60% (1343/1376 lines covered)

## Stacked PR
Base: `issue/341-detect-detailed-logs-literal` (PR #74) — merge in order after earlier PRs.

Closes manasight/manasight-docs#342

🤖 Generated with [Claude Code](https://claude.com/claude-code)