### PR TITLE
Add PR trigger to smoke test workflow

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -7,6 +7,14 @@ on:
     types: [completed]
     branches: [main]
 
+  # Run on PRs that touch parser or test code.
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "smoke-baseline.json"
+      - "smoke-corpus-manifest.toml"
+
   # Weekly on Sundays at 06:00 UTC.
   schedule:
     - cron: "0 6 * * 0"


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to the smoke test workflow with path filtering
- Smoke tests now run automatically on PRs that touch `src/`, `tests/`, `smoke-baseline.json`, or `smoke-corpus-manifest.toml`
- Catches ratchet regressions before merge instead of only post-merge on main

## Changes Made
- Added `pull_request.paths` trigger to `.github/workflows/smoke-test.yml`
- No changes to test logic or baseline — only workflow trigger configuration

## Testing
- Existing workflow logic unchanged (secret check, corpus download, ratchet comparison all identical)
- Fork PRs still skip gracefully when `TEST_DATA_TOKEN` is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)