### PR TITLE
Fix smoke baseline bless mode writing stale corpus_tag

### DIFF
--- a/smoke-corpus-manifest.toml
+++ b/smoke-corpus-manifest.toml
@@ -1,16 +1,22 @@
 # Smoke test corpus manifest
 #
 # Describes the Player.log files used for smoke testing. The actual logs live
-# in a private GitHub release (manasight/manasight-test-data, tag smoke-data-v4)
-# to keep large binaries out of the parser repo (tag smoke-data-v5). This manifest
-# is committed so that anyone can see what is tested and verify corpus integrity
-# after download.
+# in a private GitHub release (manasight/manasight-test-data) to keep large
+# binaries out of the parser repo. This manifest is committed so that anyone
+# can see what is tested and verify corpus integrity after download.
+#
+# The corpus_tag below is the single source of truth for the release tag.
+# It is read by bless mode (smoke_parsers.rs) when writing smoke-baseline.json
+# and must match the tag in .github/workflows/smoke-test.yml.
 #
 # Fields:
+#   corpus_tag     — GitHub release tag for the corpus archive
 #   filename       — name of the .log file inside the archive
 #   sha256         — hex-encoded SHA-256 hash of the file
 #   size_bytes     — file size in bytes
 #   date_captured  — date the play session was recorded (YYYY-MM-DD)
+
+corpus_tag = "smoke-data-v5"
 
 [[files]]
 filename     = "session_2026-02-22_a.log"

--- a/tests/smoke_metadata.rs
+++ b/tests/smoke_metadata.rs
@@ -15,6 +15,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 #[derive(Deserialize)]
 struct Manifest {
+    corpus_tag: String,
     files: Vec<ManifestEntry>,
 }
 
@@ -214,6 +215,35 @@ fn test_manifest_and_baseline_cover_same_files() -> TestResult {
     assert_eq!(
         manifest_files, baseline_files,
         "manifest and baseline should reference the same set of files"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_manifest_has_corpus_tag() -> TestResult {
+    let manifest = read_manifest()?;
+
+    assert!(
+        !manifest.corpus_tag.is_empty(),
+        "manifest corpus_tag should not be empty"
+    );
+    assert!(
+        manifest.corpus_tag.starts_with("smoke-data-"),
+        "manifest corpus_tag should start with 'smoke-data-', got '{}'",
+        manifest.corpus_tag
+    );
+    Ok(())
+}
+
+#[test]
+fn test_baseline_corpus_tag_matches_manifest() -> TestResult {
+    let manifest = read_manifest()?;
+    let baseline = read_baseline()?;
+
+    assert_eq!(
+        baseline.meta.corpus_tag, manifest.corpus_tag,
+        "baseline corpus_tag ('{}') should match manifest corpus_tag ('{}')",
+        baseline.meta.corpus_tag, manifest.corpus_tag
     );
     Ok(())
 }

--- a/tests/smoke_parsers.rs
+++ b/tests/smoke_parsers.rs
@@ -483,6 +483,19 @@ fn reports_to_baseline_files(
         .collect()
 }
 
+/// Reads `corpus_tag` from `smoke-corpus-manifest.toml` (single source of truth).
+fn read_corpus_tag() -> String {
+    #[derive(serde::Deserialize)]
+    struct ManifestMeta {
+        corpus_tag: String,
+    }
+
+    std::fs::read_to_string("smoke-corpus-manifest.toml")
+        .ok()
+        .and_then(|s| toml::from_str::<ManifestMeta>(&s).ok())
+        .map_or_else(|| "unknown".to_string(), |m| m.corpus_tag)
+}
+
 /// Builds a full `Baseline` from actual results for bless mode.
 fn build_baseline(actual: &std::collections::BTreeMap<String, BaselineFile>) -> Baseline {
     // Get current git commit hash for metadata, falling back gracefully.
@@ -507,7 +520,7 @@ fn build_baseline(actual: &std::collections::BTreeMap<String, BaselineFile>) -> 
                           (parser-only) smoke tests."
                 .to_string(),
             generated_from_commit: commit,
-            corpus_tag: "smoke-data-v1".to_string(),
+            corpus_tag: read_corpus_tag(),
         },
         files: actual.clone(),
     }


### PR DESCRIPTION
## Summary
- Auto-generated baseline PRs were writing `corpus_tag: "smoke-data-v1"` instead of `"smoke-data-v5"` due to a hardcoded string in `build_baseline()`
- Add `corpus_tag` field to `smoke-corpus-manifest.toml` as the single source of truth
- Bless mode now reads from the manifest instead of hardcoding

## Changes Made
- `smoke-corpus-manifest.toml`: added `corpus_tag = "smoke-data-v5"` top-level field
- `tests/smoke_parsers.rs`: `build_baseline()` reads corpus_tag from manifest via `read_corpus_tag()`
- `tests/smoke_metadata.rs`: added `test_manifest_has_corpus_tag` and `test_baseline_corpus_tag_matches_manifest` tests

## Testing
- All tests passing (898 total)
- Linting clean, formatted
- New tests validate manifest has corpus_tag and baseline matches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)