### PR TITLE
Fix: Detect new corpus files as ratchet improvements

### DIFF
--- a/tests/smoke_common/mod.rs
+++ b/tests/smoke_common/mod.rs
@@ -425,8 +425,8 @@ impl RatchetResult {
 
 /// Compares actual smoke test results against the baseline.
 ///
-/// Only compares files that appear in both the baseline and actual results.
-/// Checks per-parser claimed counts and per-event-type counts.
+/// Compares per-parser claimed counts and per-event-type counts for files in
+/// the baseline, and detects new files in actual that are not yet baselined.
 pub fn compare_against_baseline(
     baseline: &Baseline,
     actual: &BTreeMap<String, BaselineFile>,
@@ -487,6 +487,35 @@ pub fn compare_against_baseline(
                 diffs.push(RatchetDiff {
                     filename: filename.clone(),
                     metric: format!("parser/{parser_name}"),
+                    baseline_value: 0,
+                    actual_value: actual_count,
+                });
+            }
+        }
+    }
+
+    // Detect new files in actual that are not in the baseline.
+    for (filename, actual_file) in actual {
+        if baseline.files.contains_key(filename) {
+            continue;
+        }
+
+        for (parser_name, &actual_count) in &actual_file.parsers {
+            if actual_count > 0 {
+                diffs.push(RatchetDiff {
+                    filename: filename.clone(),
+                    metric: format!("parser/{parser_name}"),
+                    baseline_value: 0,
+                    actual_value: actual_count,
+                });
+            }
+        }
+
+        for (event_type, &actual_count) in &actual_file.event_types {
+            if actual_count > 0 {
+                diffs.push(RatchetDiff {
+                    filename: filename.clone(),
+                    metric: format!("event_type/{event_type}"),
                     baseline_value: 0,
                     actual_value: actual_count,
                 });

--- a/tests/smoke_ratchet.rs
+++ b/tests/smoke_ratchet.rs
@@ -216,6 +216,118 @@ fn test_ratchet_missing_actual_file_is_skipped() {
 }
 
 // ---------------------------------------------------------------------------
+// Tests: new files not in baseline
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ratchet_new_file_in_actual_is_improvement() {
+    let baseline_parsers = BTreeMap::from([("session".to_string(), 5_u64)]);
+    let baseline = make_baseline("existing.log", baseline_parsers);
+
+    // Actual contains the existing file plus a new file not in baseline.
+    let actual = BTreeMap::from([
+        (
+            "existing.log".to_string(),
+            make_actual_file(BTreeMap::from([("session".to_string(), 5_u64)])),
+        ),
+        (
+            "new_session.log".to_string(),
+            BaselineFile {
+                total_entries: 200,
+                parsers: BTreeMap::from([("gre".to_string(), 80_u64)]),
+                event_types: BTreeMap::from([("Session".to_string(), 10_u64)]),
+                unclaimed: 5,
+                double_claims: 0,
+                timestamp_failures: 2,
+            },
+        ),
+    ]);
+
+    let result = compare_against_baseline(&baseline, &actual);
+    assert!(
+        result.is_pass(),
+        "new file should be an improvement, not a regression"
+    );
+    assert_eq!(result.improvements().len(), 2); // parser/gre + event_type/Session
+    assert_eq!(result.regressions().len(), 0);
+
+    // Verify diffs reference the new file.
+    for diff in result.improvements() {
+        assert_eq!(diff.filename, "new_session.log");
+        assert_eq!(diff.baseline_value, 0);
+    }
+}
+
+#[test]
+fn test_ratchet_new_file_with_zero_counts_produces_no_diffs() {
+    let baseline_parsers = BTreeMap::from([("session".to_string(), 5_u64)]);
+    let baseline = make_baseline("existing.log", baseline_parsers);
+
+    let actual = BTreeMap::from([
+        (
+            "existing.log".to_string(),
+            make_actual_file(BTreeMap::from([("session".to_string(), 5_u64)])),
+        ),
+        (
+            "empty.log".to_string(),
+            BaselineFile {
+                total_entries: 0,
+                parsers: BTreeMap::from([("gre".to_string(), 0_u64)]),
+                event_types: BTreeMap::new(),
+                unclaimed: 0,
+                double_claims: 0,
+                timestamp_failures: 0,
+            },
+        ),
+    ]);
+
+    let result = compare_against_baseline(&baseline, &actual);
+    assert!(
+        result.diffs.is_empty(),
+        "zero-count new file should produce no diffs"
+    );
+}
+
+#[test]
+fn test_ratchet_new_file_report_shows_improvement_markers() {
+    let baseline = Baseline {
+        meta: BaselineMeta {
+            description: "test".to_string(),
+            generated_from_commit: "abc1234".to_string(),
+            corpus_tag: "test-v1".to_string(),
+        },
+        files: BTreeMap::new(), // empty baseline
+    };
+
+    let actual = BTreeMap::from([(
+        "brand_new.log".to_string(),
+        BaselineFile {
+            total_entries: 100,
+            parsers: BTreeMap::from([("session".to_string(), 5_u64)]),
+            event_types: BTreeMap::from([("Session".to_string(), 5_u64)]),
+            unclaimed: 10,
+            double_claims: 0,
+            timestamp_failures: 5,
+        },
+    )]);
+
+    let result = compare_against_baseline(&baseline, &actual);
+    let report = result.format_report();
+    assert!(
+        report.contains("[+]"),
+        "report should show [+] for new file: {report}"
+    );
+    assert!(
+        report.contains("brand_new.log"),
+        "report should reference new filename: {report}"
+    );
+    assert!(
+        report.contains("0 -> 5"),
+        "report should show 0 -> actual for new file metrics: {report}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Tests: report formatting
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `compare_against_baseline()` only iterated over files in the baseline, so new corpus files were silently ignored — no `[+]` markers emitted, CI skipped baseline update PR creation
- Added a second pass that detects files in actual results not present in the baseline and emits `RatchetDiff` entries for their parser and event_type counts (0 → actual)

## Changes Made
- `tests/smoke_common/mod.rs`: Added new-file detection loop after the existing baseline-file comparison loop; updated doc comment
- `tests/smoke_ratchet.rs`: Added 3 tests — new file as improvement, new file with zero counts produces no diffs, report formatting for new files

## Testing
- All tests passing (948 tests)
- Linting clean, formatted
- Code coverage: 96.99% coverage, 1420/1464 lines covered

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)