### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v5",
+    "corpus_tag": "manasight-corpus-v8",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "f9656c1"
+    "generated_from_commit": "d7c7029"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -10,7 +10,7 @@
       "event_types": {
         "ClientAction": 2026,
         "DetailedLoggingStatus": 1,
-        "EventLifecycle": 6,
+        "EventLifecycle": 7,
         "GameResult": 5,
         "GameState": 4381,
         "Inventory": 7,
@@ -24,7 +24,7 @@
         "draft_bot": 0,
         "draft_complete": 0,
         "draft_human": 0,
-        "event_lifecycle": 6,
+        "event_lifecycle": 7,
         "gre": 2617,
         "inventory": 7,
         "match_state": 10,
@@ -34,7 +34,7 @@
       },
       "timestamp_failures": 164,
       "total_entries": 4914,
-      "unclaimed": 234
+      "unclaimed": 233
     },
     "session_2026-02-22_0000_ecl-premier-uw-merfolk.log": {
       "double_claims": 0,
@@ -43,7 +43,7 @@
         "DetailedLoggingStatus": 1,
         "DraftComplete": 2,
         "DraftHuman": 77,
-        "EventLifecycle": 6,
+        "EventLifecycle": 7,
         "GameResult": 4,
         "GameState": 3478,
         "Inventory": 5,
@@ -57,7 +57,7 @@
         "draft_bot": 0,
         "draft_complete": 2,
         "draft_human": 77,
-        "event_lifecycle": 6,
+        "event_lifecycle": 7,
         "gre": 2172,
         "inventory": 5,
         "match_state": 8,
@@ -67,7 +67,7 @@
       },
       "timestamp_failures": 214,
       "total_entries": 3996,
-      "unclaimed": 227
+      "unclaimed": 226
     },
     "session_2026-02-23_0000_standard-bo1.log": {
       "double_claims": 0,
@@ -552,6 +552,97 @@
       "timestamp_failures": 198,
       "total_entries": 322,
       "unclaimed": 227
+    },
+    "session_2026-04-11_1835_firewall.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 81,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameState": 164,
+        "Inventory": 4,
+        "MatchState": 2,
+        "Rank": 4,
+        "Session": 14
+      },
+      "parsers": {
+        "client_actions": 81,
+        "collection": 0,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 42,
+        "inventory": 4,
+        "match_state": 2,
+        "metadata": 1,
+        "rank": 4,
+        "session": 14
+      },
+      "timestamp_failures": 135,
+      "total_entries": 313,
+      "unclaimed": 163
+    },
+    "session_2026-04-11_1900_clumsy-directional.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 48,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 4,
+        "GameResult": 1,
+        "GameState": 154,
+        "Inventory": 5,
+        "MatchState": 5,
+        "Rank": 5,
+        "Session": 26
+      },
+      "parsers": {
+        "client_actions": 48,
+        "collection": 0,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 4,
+        "gre": 71,
+        "inventory": 5,
+        "match_state": 5,
+        "metadata": 1,
+        "rank": 5,
+        "session": 26
+      },
+      "timestamp_failures": 188,
+      "total_entries": 383,
+      "unclaimed": 218
+    },
+    "session_2026-04-11_1930_clumsy-outbound-ranked.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 45,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameState": 115,
+        "Inventory": 2,
+        "MatchState": 1,
+        "Rank": 2,
+        "Session": 4
+      },
+      "parsers": {
+        "client_actions": 45,
+        "collection": 0,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 43,
+        "inventory": 2,
+        "match_state": 1,
+        "metadata": 1,
+        "rank": 2,
+        "session": 4
+      },
+      "timestamp_failures": 62,
+      "total_entries": 182,
+      "unclaimed": 82
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.