### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v10",
+    "corpus_tag": "manasight-corpus-v12",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "cb1e32f"
+    "generated_from_commit": "5cca3d6"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -704,6 +704,37 @@
       "timestamp_failures": 142,
       "total_entries": 412,
       "unclaimed": 174
+    },
+    "session_2026-04-12_1045_pfctl-directional.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 429,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 4,
+        "GameResult": 2,
+        "GameState": 880,
+        "Inventory": 7,
+        "MatchState": 8,
+        "Rank": 7,
+        "Session": 30
+      },
+      "parsers": {
+        "client_actions": 429,
+        "collection": 0,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 4,
+        "gre": 444,
+        "inventory": 7,
+        "match_state": 8,
+        "metadata": 1,
+        "rank": 7,
+        "session": 30
+      },
+      "timestamp_failures": 248,
+      "total_entries": 1221,
+      "unclaimed": 291
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.