### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v12",
+    "corpus_tag": "manasight-corpus-v13",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "5cca3d6"
+    "generated_from_commit": "9b9cfee"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -735,6 +735,37 @@
       "timestamp_failures": 248,
       "total_entries": 1221,
       "unclaimed": 291
+    },
+    "session_2026-04-12_1145_wifi-disable.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 413,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameResult": 2,
+        "GameState": 827,
+        "Inventory": 4,
+        "MatchState": 5,
+        "Rank": 4,
+        "Session": 8
+      },
+      "parsers": {
+        "client_actions": 413,
+        "collection": 0,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 353,
+        "inventory": 4,
+        "match_state": 5,
+        "metadata": 1,
+        "rank": 4,
+        "session": 8
+      },
+      "timestamp_failures": 112,
+      "total_entries": 939,
+      "unclaimed": 149
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.