### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v13",
+    "corpus_tag": "manasight-corpus-v14",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "9b9cfee"
+    "generated_from_commit": "3f81db6"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -766,6 +766,37 @@
       "timestamp_failures": 112,
       "total_entries": 939,
       "unclaimed": 149
+    },
+    "session_2026-04-12_1240_edge-cases.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 199,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameResult": 2,
+        "GameState": 412,
+        "Inventory": 3,
+        "MatchState": 4,
+        "Rank": 3,
+        "Session": 15
+      },
+      "parsers": {
+        "client_actions": 199,
+        "collection": 0,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 175,
+        "inventory": 3,
+        "match_state": 4,
+        "metadata": 1,
+        "rank": 3,
+        "session": 15
+      },
+      "timestamp_failures": 130,
+      "total_entries": 553,
+      "unclaimed": 151
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.