### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v14",
+    "corpus_tag": "manasight-corpus-v15",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "3f81db6"
+    "generated_from_commit": "2c0c617"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -549,9 +549,9 @@
         "rank": 5,
         "session": 25
       },
-      "timestamp_failures": 198,
-      "total_entries": 322,
-      "unclaimed": 227
+      "timestamp_failures": 243,
+      "total_entries": 367,
+      "unclaimed": 272
     },
     "session_2026-04-11_1835_firewall.log": {
       "double_claims": 0,
@@ -579,9 +579,9 @@
         "rank": 4,
         "session": 14
       },
-      "timestamp_failures": 135,
-      "total_entries": 313,
-      "unclaimed": 163
+      "timestamp_failures": 162,
+      "total_entries": 340,
+      "unclaimed": 190
     },
     "session_2026-04-11_1900_clumsy-directional.log": {
       "double_claims": 0,
@@ -610,9 +610,9 @@
         "rank": 5,
         "session": 26
       },
-      "timestamp_failures": 188,
-      "total_entries": 383,
-      "unclaimed": 218
+      "timestamp_failures": 233,
+      "total_entries": 428,
+      "unclaimed": 263
     },
     "session_2026-04-11_1930_clumsy-outbound-ranked.log": {
       "double_claims": 0,
@@ -640,9 +640,9 @@
         "rank": 2,
         "session": 4
       },
-      "timestamp_failures": 62,
-      "total_entries": 182,
-      "unclaimed": 82
+      "timestamp_failures": 69,
+      "total_entries": 189,
+      "unclaimed": 89
     },
     "session_2026-04-12_0844_edge-cases.log": {
       "double_claims": 0,
@@ -671,9 +671,9 @@
         "rank": 3,
         "session": 12
       },
-      "timestamp_failures": 128,
-      "total_entries": 1381,
-      "unclaimed": 150
+      "timestamp_failures": 152,
+      "total_entries": 1405,
+      "unclaimed": 174
     },
     "session_2026-04-12_1010_pfctl-bidirectional.log": {
       "double_claims": 0,
@@ -701,9 +701,9 @@
         "rank": 4,
         "session": 14
       },
-      "timestamp_failures": 142,
-      "total_entries": 412,
-      "unclaimed": 174
+      "timestamp_failures": 169,
+      "total_entries": 439,
+      "unclaimed": 201
     },
     "session_2026-04-12_1045_pfctl-directional.log": {
       "double_claims": 0,
@@ -732,9 +732,9 @@
         "rank": 7,
         "session": 30
       },
-      "timestamp_failures": 248,
-      "total_entries": 1221,
-      "unclaimed": 291
+      "timestamp_failures": 300,
+      "total_entries": 1273,
+      "unclaimed": 343
     },
     "session_2026-04-12_1145_wifi-disable.log": {
       "double_claims": 0,
@@ -763,9 +763,9 @@
         "rank": 4,
         "session": 8
       },
-      "timestamp_failures": 112,
-      "total_entries": 939,
-      "unclaimed": 149
+      "timestamp_failures": 126,
+      "total_entries": 953,
+      "unclaimed": 163
     },
     "session_2026-04-12_1240_edge-cases.log": {
       "double_claims": 0,
@@ -794,9 +794,40 @@
         "rank": 3,
         "session": 15
       },
-      "timestamp_failures": 130,
-      "total_entries": 553,
-      "unclaimed": 151
+      "timestamp_failures": 158,
+      "total_entries": 581,
+      "unclaimed": 179
+    },
+    "session_2026-04-14_1720.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 24,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 4,
+        "GameResult": 3,
+        "GameState": 246,
+        "Inventory": 4,
+        "MatchState": 6,
+        "Rank": 4,
+        "Session": 4
+      },
+      "parsers": {
+        "client_actions": 24,
+        "collection": 0,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 4,
+        "gre": 102,
+        "inventory": 4,
+        "match_state": 6,
+        "metadata": 1,
+        "rank": 4,
+        "session": 4
+      },
+      "timestamp_failures": 91,
+      "total_entries": 282,
+      "unclaimed": 133
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.