### PR TITLE
chore: prepare for first crates.io publish (v0.1.1)

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,59 @@
+name: Publish crate to crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. v0.1.1)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.tag }} to crates.io
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
+
+      - name: Verify Cargo.toml version matches input tag
+        run: |
+          set -euo pipefail
+          pkg_version=$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')
+          expected="v${pkg_version}"
+          if [ "${expected}" != "${{ inputs.tag }}" ]; then
+            echo "::error::Cargo.toml version (${pkg_version}) does not match input tag (${{ inputs.tag }})" >&2
+            exit 1
+          fi
+
+      - name: Run tests
+        run: cargo test --all-features --locked
+
+      - name: Lint (clippy)
+        run: cargo clippy --all-targets --all-features --locked -- -D warnings
+
+      - name: Verify formatting
+        run: cargo fmt --all -- --check
+
+      - name: Authenticate with crates.io (trusted publishing)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.1.0] - Unreleased
+## [0.1.1] - 2026-04-15
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manasight-parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` version `0.1.0` → `0.1.1` and dates the CHANGELOG section (first published version will be 0.1.1).
- Adds `.github/workflows/publish-crate.yml` — manual-dispatch workflow that publishes the crate to crates.io via **Trusted Publishing (OIDC)**. No long-lived `CARGO_REGISTRY_TOKEN` is stored in GitHub Secrets.

## Workflow hardening (public-repo appropriate)

- `workflow_dispatch` only — not triggered by `push`, `pull_request`, `pull_request_target`, or `workflow_run` (the latter two are server-side blocked by crates.io for trusted publishing anyway).
- Top-level `permissions: {}`; publish job gets only `contents: read` + `id-token: write`.
- Runs under a GitHub Environment (`crates-io`) so a **required reviewer** must approve each publish, and deployment can be restricted to `v*` tags.
- Checks out the exact input `tag` and refuses to publish if `Cargo.toml` version does not match.
- Runs `cargo test --locked`, `cargo clippy -D warnings`, and `cargo fmt --check` as gates before publish.
- All third-party actions pinned to SHA (`actions/checkout` v6.0.2, `actions-rust-lang/setup-rust-toolchain` v1, `rust-lang/crates-io-auth-action` v1.0.4).
- OIDC token from `crates-io-auth-action` is short-lived (30 min) and auto-revoked by the action's post-step.

## Rollout plan (documented here so the PR is self-contained)

1. Merge this PR.
2. **Manual first publish of v0.1.1** from a workstation with a temporary crates.io API token (unavoidable — crates.io does not yet support pending trusted publishers for brand-new crates).
3. Revoke the temporary API token immediately after the first publish succeeds.
4. Register the trusted publisher on crates.io for the new crate: owner=`manasight`, repo=`manasight-parser`, workflow=`publish-crate.yml`, environment=`crates-io`.
5. Create the `crates-io` GitHub Environment in repo settings (required reviewer + `v*` tag deployment rule).
6. Enable **Enforce Trusted Publishing** on the crate's crates.io settings page (disables API-token publishing entirely going forward).
7. Subsequent releases: tag `vX.Y.Z`, dispatch `publish-crate.yml` with the tag as input.

## Test plan

- [x] `cargo fmt --all -- --check` passes on branch HEAD
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` passes
- [x] `cargo test --all-features --locked` passes (all unit, integration, and doc tests)
- [x] `cargo publish --dry-run --locked` packages 76 files (170.8 KiB compressed) and compiles cleanly from the packaged tarball
- [ ] Workflow syntax reviewed
- [ ] Dispatch dry-run after first publish + trusted publisher registration lands — will be validated on v0.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)