### PR TITLE
docs: add crates.io install instructions (v0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.2] - 2026-04-15
+
+### Added
+
+- Installation instructions in README for crates.io consumers
+
 ## [0.1.1] - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manasight-parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 
 MTG Arena log file parser — a Rust library crate that reads Arena's `Player.log` and emits typed game events via an async event bus.
 
+## Installation
+
+```sh
+cargo add manasight-parser
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[dependencies]
+manasight-parser = "0.1"
+```
+
+Requires Rust 1.93.0 or later.
+
 ## Architecture
 
 ```text


### PR DESCRIPTION
## Summary

- Adds an **Installation** section to the README pointing users to `cargo add manasight-parser` / Cargo.toml snippet, now that the crate is published on crates.io.
- Bumps version `0.1.1` → `0.1.2` and adds a CHANGELOG entry.
- Doubles as the end-to-end test of `publish-crate.yml` via trusted publishing — this is the first release that will go through the workflow rather than a manual workstation publish.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -D warnings` passes
- [x] `cargo test --locked` passes
- [ ] After merge: tag `v0.1.2`, push, and dispatch `publish-crate.yml` → approve environment gate → verify published on crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)