### PR TITLE
chore: release v0.2.0 (breaking)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manasight-parser"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or in `Cargo.toml`:
 
 ```toml
 [dependencies]
-manasight-parser = "0.1"
+manasight-parser = "0.2"
 ```
 
 Requires Rust 1.93.0 or later.


### PR DESCRIPTION
## Summary

Release prep for v0.2.0. Bumps `Cargo.toml`, refreshes `Cargo.lock`, and updates the README install snippet to track 0.2.x.

## Why a minor bump (0.1.2 → 0.2.0)

Two public-API breaking changes have landed since v0.1.2:

1. **`LineBuffer::push_line` return type changed** from `Option<LogEntry>` to `Vec<LogEntry>` (#160 / #162). This was needed so a single-line entry can flush in the same `push_line` call that produced it, even when a prior multi-line entry also needs to flush in that call. External consumers using `LineBuffer` directly will need to switch from `if let Some(entry) = buf.push_line(...)` to `entries.extend(buf.push_line(...))`.
2. **Removed the dead `StartHook` PlayerCards collection-event path** (#147 / #149). The `parsers::collection` module and its public types are gone; `inventory` is the only supported `StartHook` snapshot now.

For a 0.x crate, breaking changes bump the minor per Cargo SemVer.

## Other changes since v0.1.2 (non-breaking)

- Phase 2 of #153: silenced routine post-flush "headerless line" warnings (#161 / #163). The warning now fires only for true file-start / post-rotation anomalies, not for routine Unity stdout noise between entries.
- Smoke baseline auto-update (#159).

## Release process (for after this PR merges)

1. Tag the merge commit: `git tag v0.2.0 && git push origin v0.2.0` — fires `release.yml` (builds `scrub` binaries for 4 platforms, creates a GitHub Release).
2. Manually trigger the `Publish crate to crates.io` workflow with `tag: v0.2.0` — runs `cargo publish --locked` via trusted publishing.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features --locked` — all tests pass (matches what `publish-crate.yml` will run on the tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)