### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v17",
+    "corpus_tag": "manasight-corpus-v18",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "c3b9457"
+    "generated_from_commit": "1a00700"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -861,6 +861,36 @@
       "timestamp_failures": 189,
       "total_entries": 2153,
       "unclaimed": 268
+    },
+    "session_2026-04-27_2230.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 1183,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameResult": 3,
+        "GameState": 1999,
+        "Inventory": 4,
+        "MatchState": 6,
+        "Rank": 4,
+        "Session": 4
+      },
+      "parsers": {
+        "client_actions": 1183,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 837,
+        "inventory": 4,
+        "match_state": 6,
+        "metadata": 1,
+        "rank": 4,
+        "session": 4
+      },
+      "timestamp_failures": 100,
+      "total_entries": 2189,
+      "unclaimed": 148
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.