### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v18",
+    "corpus_tag": "manasight-corpus-v19",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "1a00700"
+    "generated_from_commit": "9200b16"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -891,6 +891,35 @@
       "timestamp_failures": 100,
       "total_entries": 2189,
       "unclaimed": 148
+    },
+    "session_2026-04-29_2128.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 826,
+        "DetailedLoggingStatus": 1,
+        "GameResult": 2,
+        "GameState": 1145,
+        "Inventory": 3,
+        "MatchState": 4,
+        "Rank": 3,
+        "Session": 2
+      },
+      "parsers": {
+        "client_actions": 826,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 0,
+        "gre": 257,
+        "inventory": 3,
+        "match_state": 4,
+        "metadata": 1,
+        "rank": 3,
+        "session": 2
+      },
+      "timestamp_failures": 66,
+      "total_entries": 1196,
+      "unclaimed": 100
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.