### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v19",
+    "corpus_tag": "manasight-corpus-v20",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "9200b16"
+    "generated_from_commit": "1f19f8a"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -920,6 +920,35 @@
       "timestamp_failures": 66,
       "total_entries": 1196,
       "unclaimed": 100
+    },
+    "session_2026-04-29_2201.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 695,
+        "DetailedLoggingStatus": 1,
+        "GameResult": 1,
+        "GameState": 597,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 2
+      },
+      "parsers": {
+        "client_actions": 695,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 0,
+        "gre": 191,
+        "inventory": 2,
+        "match_state": 2,
+        "metadata": 1,
+        "rank": 2,
+        "session": 2
+      },
+      "timestamp_failures": 60,
+      "total_entries": 983,
+      "unclaimed": 88
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.