### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v21",
+    "corpus_tag": "manasight-corpus-v22",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "b21c23b"
+    "generated_from_commit": "0f634dd"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -978,6 +978,35 @@
       "timestamp_failures": 199,
       "total_entries": 1793,
       "unclaimed": 284
+    },
+    "session_2026-04-30_0000.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 359,
+        "DetailedLoggingStatus": 1,
+        "GameResult": 1,
+        "GameState": 654,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 1
+      },
+      "parsers": {
+        "client_actions": 359,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 0,
+        "gre": 179,
+        "inventory": 2,
+        "match_state": 2,
+        "metadata": 1,
+        "rank": 2,
+        "session": 1
+      },
+      "timestamp_failures": 61,
+      "total_entries": 638,
+      "unclaimed": 92
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.