### PR TITLE
Fix manasight/manasight-docs#590: P-1 ConnectResp ordered emit + P-2 SubmitDeckResp Bo3 round-trip

### DIFF
--- a/src/parsers/client_actions.rs
+++ b/src/parsers/client_actions.rs
@@ -299,6 +299,11 @@ fn build_select_n_resp_payload(
 /// - `deck.deckCards` — array of card GRP IDs in the main deck
 /// - `deck.sideboardCards` — array of card GRP IDs in the sideboard
 ///
+/// Spec: AC-LIFE-1 (deck-tracker-overlay) — Bo3 G2/G3 transitions reset the
+/// deck tracker by capturing this payload during sideboarding. The post-
+/// sideboard `deckCards` becomes the next game's library snapshot before the
+/// new GRE `ConnectResp` arrives.
+///
 /// The output payload has the shape:
 ///
 /// ```json
@@ -786,6 +791,82 @@ mod tests {
             assert_eq!(payload["type"], "submit_deck_resp");
             assert_eq!(payload["deck_cards"], serde_json::json!([]));
             assert_eq!(payload["sideboard_cards"], serde_json::json!([]));
+        } else {
+            return Err("Expected GameEvent::ClientAction".into());
+        }
+        Ok(())
+    }
+
+    /// Bo3-shaped `SubmitDeckResp` with 60 main + 15 sideboard cards.
+    ///
+    /// Wire-shape inspired by corpus session
+    /// `2026-03-11_2124_trad-standard-bo3.log.gz` (3 `SubmitDeckResp`
+    /// occurrences across the Bo3 match). Drives spec AC-LIFE-1: the parser
+    /// must round-trip the post-sideboard deck submission so Group B's
+    /// lifecycle layer can reset the deck tracker between G1 and G2/G3.
+    #[test]
+    fn test_try_parse_submit_deck_resp_bo3_shaped_round_trip() -> TestResult {
+        // 60-card main deck (Bo3 minimum): 19 lands + 41 spells, with a few
+        // 4-of playsets to mirror real constructed decks.
+        let deck_cards: Vec<i64> = (0..19)
+            .map(|_| 95815_i64) // 19x basic land
+            .chain([51307_i64; 3]) // 3x utility spell
+            .chain([92065_i64]) // 1x singleton
+            .chain([86715_i64; 2]) // 2x curve filler
+            .chain([91549_i64; 4]) // 4x core threat
+            .chain([92073_i64; 2])
+            .chain([92081_i64; 4])
+            .chain([92089_i64; 4])
+            .chain([92090_i64; 4])
+            .chain([92102_i64])
+            .chain([96598_i64; 3])
+            .chain([96608_i64; 4])
+            .chain([97544_i64])
+            .chain([97823_i64; 4])
+            .chain([97964_i64; 4])
+            .collect();
+        assert_eq!(deck_cards.len(), 60, "main deck must be 60 cards for Bo3");
+
+        // 15-card sideboard (Bo3 maximum).
+        let sideboard_cards: Vec<i64> = (0..15).map(|i| 70000_i64 + i).collect();
+        assert_eq!(
+            sideboard_cards.len(),
+            15,
+            "sideboard must be 15 cards for Bo3"
+        );
+
+        let inner = serde_json::json!({
+            "type": "ClientMessageType_SubmitDeckResp",
+            "submitDeckResp": {
+                "deck": {
+                    "deckCards": deck_cards,
+                    "sideboardCards": sideboard_cards
+                }
+            },
+            "gameStateId": 196,
+            "respId": 318
+        });
+        let body = wrap_client_to_gre(&inner);
+        let entry = unity_entry(&body);
+        let result = try_parse(&entry, Some(test_timestamp()));
+
+        assert!(result.is_some());
+        if let Some(GameEvent::ClientAction(event)) = &result {
+            let payload = event.payload();
+            assert_eq!(payload["type"], "submit_deck_resp");
+
+            let parsed_deck = payload["deck_cards"]
+                .as_array()
+                .ok_or("deck_cards missing or not an array")?;
+            assert_eq!(parsed_deck.len(), 60);
+
+            let parsed_sideboard = payload["sideboard_cards"]
+                .as_array()
+                .ok_or("sideboard_cards missing or not an array")?;
+            assert_eq!(parsed_sideboard.len(), 15);
+
+            assert_eq!(payload["game_state_id"], 196);
+            assert_eq!(payload["resp_id"], 318);
         } else {
             return Err("Expected GameEvent::ClientAction".into());
         }

--- a/src/parsers/gre/connect_resp.rs
+++ b/src/parsers/gre/connect_resp.rs
@@ -490,6 +490,46 @@ mod tests {
         }
     }
 
+    // -- Bundled batch (ConnectResp + sibling GSM) ----------------------------
+
+    mod bundled_batch {
+        use super::*;
+
+        /// Wire-shape inspiration: corpus session
+        /// `2026-02-22_0000_ecl-premier-bg-elves` line 22433. The
+        /// `greToClientMessages` array carries `[ConnectResp,
+        /// DieRollResultsResp, GameStateMessage]`. The parser must emit the
+        /// `ConnectResp` event first, followed by the GSM in source-array
+        /// order; the unhandled `DieRollResultsResp` is dropped.
+        #[test]
+        fn test_try_parse_connect_resp_bundled_with_gsm_emits_two_events() {
+            let body = connect_resp_with_bundled_gsm_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 2);
+        }
+
+        #[test]
+        fn test_try_parse_connect_resp_bundled_with_gsm_first_event_is_connect_resp() {
+            let body = connect_resp_with_bundled_gsm_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 2);
+            let first = game_state_payload(&results[0]);
+            assert_eq!(first["type"], "connect_resp");
+        }
+
+        #[test]
+        fn test_try_parse_connect_resp_bundled_with_gsm_second_event_is_gsm() {
+            let body = connect_resp_with_bundled_gsm_body();
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(results.len(), 2);
+            let second = game_state_payload(&results[1]);
+            assert_eq!(second["type"], "game_state_message");
+        }
+    }
+
     // -- Internal helpers ----------------------------------------------------
 
     mod card_id_helpers {

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -146,30 +146,25 @@ pub fn try_parse(
         return Vec::new();
     };
 
-    // Try ConnectResp first (highest priority, emitted once at game start).
+    // Build the ordered event list: ConnectResp (if present) followed by all
+    // sibling GameStateMessage / QueuedGameStateMessage entries in source-array
+    // order. Arena bundles `[ConnectResp, DieRollResultsResp, GSM]` in 2/7
+    // captured ConnectResps, and the GSM in those bundles hydrates initial
+    // library/hand state. The previous early-return after ConnectResp silently
+    // dropped those siblings.
+    let mut events = Vec::new();
     if let Some(connect_resp_msg) = find_message_by_type(messages, CONNECT_RESP_TYPE) {
         let payload = connect_resp::build_connect_resp_payload(connect_resp_msg, &parsed);
         let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-        return vec![GameEvent::GameState(GameStateEvent::new(metadata, payload))];
+        events.push(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
     }
 
     // Iterate ALL GameStateMessage and QueuedGameStateMessage entries.
     // Arena batches multiple GSMs into a single greToClientMessages array;
     // processing only the first silently discards the majority of updates.
-    let mut events = Vec::new();
     for msg in messages {
-        let msg_type = msg.get("type").and_then(serde_json::Value::as_str);
-        if let Some(GAME_STATE_MESSAGE_TYPE | QUEUED_GAME_STATE_MESSAGE_TYPE) = msg_type {
-            let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-            if game_result::is_game_over(msg) && !game_result::is_match_complete(msg) {
-                let payload = game_result::build_game_result_payload(msg);
-                events.push(GameEvent::GameResult(GameResultEvent::new(
-                    metadata, payload,
-                )));
-            } else if !game_result::is_game_over(msg) {
-                let payload = game_state::build_game_state_message_payload(msg);
-                events.push(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
-            }
+        if let Some(event) = emit_gsm_event(msg, body, timestamp) {
+            events.push(event);
         }
     }
 
@@ -192,6 +187,47 @@ pub fn try_parse(
     // Unrecognized GRE message type — log and skip.
     ::log::debug!("greToClientEvent: no recognized message type found");
     Vec::new()
+}
+
+/// Builds a single [`GameEvent`] from a `GameStateMessage` /
+/// `QueuedGameStateMessage` entry, returning `None` for any other GRE message
+/// type (e.g. `ConnectResp`, `DieRollResultsResp`, noise types).
+///
+/// Encapsulates the GameResult-vs-GameState branch: when the embedded
+/// `gameInfo.stage == GameStage_GameOver` and `matchState != MatchState_MatchComplete`,
+/// emits a [`GameEvent::GameResult`] (Class 3 batch trigger); when the stage is
+/// `GameStage_GameOver` with `matchState == MatchState_MatchComplete`, returns
+/// `None` so the duplicate match-complete signal is suppressed.
+fn emit_gsm_event(
+    msg: &serde_json::Value,
+    body: &str,
+    timestamp: Option<chrono::DateTime<chrono::Utc>>,
+) -> Option<GameEvent> {
+    let msg_type = msg.get("type").and_then(serde_json::Value::as_str)?;
+    if !matches!(
+        msg_type,
+        GAME_STATE_MESSAGE_TYPE | QUEUED_GAME_STATE_MESSAGE_TYPE
+    ) {
+        return None;
+    }
+
+    let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
+    if game_result::is_game_over(msg) {
+        if game_result::is_match_complete(msg) {
+            // Suppress the duplicate match-complete signal — the prior
+            // game-complete entry in the same batch already produced the
+            // GameResult event.
+            None
+        } else {
+            let payload = game_result::build_game_result_payload(msg);
+            Some(GameEvent::GameResult(GameResultEvent::new(
+                metadata, payload,
+            )))
+        }
+    } else {
+        let payload = game_state::build_game_state_message_payload(msg);
+        Some(GameEvent::GameState(GameStateEvent::new(metadata, payload)))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/parsers/gre/test_fixtures.rs
+++ b/src/parsers/gre/test_fixtures.rs
@@ -452,6 +452,85 @@ pub(super) fn batched_dual_game_over_body() -> String {
     )
 }
 
+/// Helper: build a GRE event body modeled on the bundled batch shape captured
+/// in corpus session `2026-02-22_0000_ecl-premier-bg-elves` line 22433:
+/// `[GREMessageType_ConnectResp, GREMessageType_DieRollResultsResp,
+/// GREMessageType_GameStateMessage]` in a single `greToClientMessages` array.
+///
+/// Used to verify the parser emits the `ConnectResp` event followed by the
+/// sibling GSM in source-array order, dropping only the unhandled
+/// `DieRollResultsResp`. R2 corpus inspection found this shape in 2/7 captured
+/// `ConnectResp` entries.
+pub(super) fn connect_resp_with_bundled_gsm_body() -> String {
+    format!(
+        "[UnityCrossThreadLogger]greToClientEvent\n{}",
+        serde_json::json!({
+            "greToClientEvent": {
+                "greToClientMessages": [
+                    {
+                        "type": "GREMessageType_ConnectResp",
+                        "systemSeatIds": [1, 2],
+                        "msgId": 2,
+                        "gameStateId": 0,
+                        "connectResp": {
+                            "status": "ConnectionStatus_Success",
+                            "deckMessage": {
+                                "deckCards": [
+                                    98421, 98502, 98485, 98408, 98408, 98404,
+                                    98317, 98514, 98442, 98558, 98579, 98506
+                                ],
+                                "sideboardCards": [98499, 98439, 98457]
+                            },
+                            "settings": {
+                                "autoPassOption": "AutoPassOption_ResolveMyStackEffects"
+                            }
+                        }
+                    },
+                    {
+                        "type": "GREMessageType_DieRollResultsResp",
+                        "systemSeatIds": [1, 2],
+                        "msgId": 3,
+                        "dieRollResultsResp": {
+                            "playerDieRolls": [
+                                {"systemSeatId": 1, "rollValue": 9},
+                                {"systemSeatId": 2, "rollValue": 11}
+                            ]
+                        }
+                    },
+                    {
+                        "type": "GREMessageType_GameStateMessage",
+                        "systemSeatIds": [2],
+                        "msgId": 4,
+                        "gameStateId": 1,
+                        "gameStateMessage": {
+                            "type": "GameStateType_Full",
+                            "gameStateId": 1,
+                            "gameInfo": {
+                                "matchID": "27011c79-bundled-batch",
+                                "gameNumber": 1,
+                                "stage": "GameStage_Start",
+                                "type": "GameType_Duel",
+                                "matchState": "MatchState_GameInProgress",
+                                "mulliganType": "MulliganType_London"
+                            },
+                            "zones": [
+                                {
+                                    "zoneId": 32,
+                                    "type": "ZoneType_Library",
+                                    "visibility": "Visibility_Hidden",
+                                    "ownerSeatId": 1,
+                                    "objectInstanceIds": [120, 121, 122, 123, 124]
+                                }
+                            ],
+                            "gameObjects": []
+                        }
+                    }
+                ]
+            }
+        })
+    )
+}
+
 /// Helper: build a `GameStateMessage` with an empty `gameStateMessage`
 /// (no zones, no objects, no game info).
 pub(super) fn empty_game_state_message_body() -> String {


### PR DESCRIPTION
## Summary
- P-1: Refactor `gre/mod.rs` to emit `ConnectResp` followed by all sibling GSMs in array order (was: silently dropped after early-return). Extract shared `emit_gsm_event` helper.
- P-2: Add Bo3-shaped `SubmitDeckResp` fixture round-trip test + AC-LIFE-1 docstring (handler already complete).

## Changes Made
- `src/parsers/gre/mod.rs`: extracted `emit_gsm_event`, replaced `ConnectResp` early-return with ordered emit + GSM iteration
- `src/parsers/gre/test_fixtures.rs`: new `connect_resp_with_bundled_gsm_body()` fixture builder
- `src/parsers/gre/connect_resp.rs`: new bundled-batch ordered-emit test (3 assertions)
- `src/parsers/client_actions.rs`: new Bo3 `SubmitDeckResp` round-trip test (60 main + 15 sideboard) + AC-LIFE-1 docstring on `build_submit_deck_resp_payload`

## Testing
- All tests passing (1117 -> 1121, +4 new)
- Linting clean (`cargo clippy --all-targets --all-features -- -D warnings`), formatted
- Code coverage: 97.16% (1607/1654 lines)

## Stacked PR
Base: `main` -- first PR in the stack (#590 + #591 from mega-epic #589 Group P).

Closes manasight/manasight-docs#590

🤖 Generated with [Claude Code](https://claude.com/claude-code)