### PR TITLE
Fix manasight/manasight-parser#182: emit game_state_type discriminator on GSM payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manasight-parser"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/src/parsers/gre/game_state.rs
+++ b/src/parsers/gre/game_state.rs
@@ -13,6 +13,7 @@ use super::turn_info::extract_turn_info;
 /// ```json
 /// {
 ///   "type": "game_state_message",
+///   "game_state_type": "GameStateType_Full",
 ///   "msg_id": 5,
 ///   "game_state_id": 42,
 ///   "zones": [ { "zone_id": 1, "zone_type": "ZoneType_Hand", ... }, ... ],
@@ -56,6 +57,14 @@ pub(super) fn build_game_state_message_payload(gre_msg: &serde_json::Value) -> s
         "game_state_message"
     };
 
+    // Inner gameStateMessage.type is the GameStateType_Full / GameStateType_Diff
+    // discriminator. Always emit; None serializes to JSON null so the key is
+    // always present in the payload regardless of source presence.
+    let game_state_type = gsm
+        .and_then(|g| g.get("type"))
+        .and_then(serde_json::Value::as_str)
+        .map(String::from);
+
     // Extract zones from gameStateMessage.zones[].
     let zones = extract_zones(gsm);
 
@@ -93,6 +102,7 @@ pub(super) fn build_game_state_message_payload(gre_msg: &serde_json::Value) -> s
 
     serde_json::json!({
         "type": payload_type,
+        "game_state_type": game_state_type,
         "msg_id": msg_id,
         "game_state_id": game_state_id,
         "zones": zones,
@@ -1795,5 +1805,97 @@ mod tests {
         assert_eq!(obj["object_type"], "GameObjectType_Card");
         assert!(obj.get("object_source_grp_id").is_none());
         assert!(obj.get("parent_id").is_none());
+    }
+
+    // -- game_state_type discriminator extraction -----------------------------
+
+    mod game_state_type_extraction {
+        use super::*;
+
+        /// Helper: extract the `game_state_message`-typed payload from a
+        /// possibly multi-event parse result.
+        fn first_game_state_payload(body: &str) -> serde_json::Value {
+            let entry = unity_entry(body);
+            try_parse(&entry, Some(test_timestamp()))
+                .into_iter()
+                .find_map(|e| {
+                    if matches!(e, crate::events::GameEvent::GameState(_)) {
+                        Some(game_state_payload(&e).clone())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| unreachable!())
+        }
+
+        #[test]
+        fn test_game_state_type_full_emits_string() {
+            let body = format!(
+                "[UnityCrossThreadLogger]greToClientEvent\n{}",
+                serde_json::json!({
+                    "greToClientEvent": {
+                        "greToClientMessages": [{
+                            "type": "GREMessageType_GameStateMessage",
+                            "msgId": 50,
+                            "gameStateId": 200,
+                            "gameStateMessage": {
+                                "type": "GameStateType_Full",
+                                "zones": [],
+                                "gameObjects": []
+                            }
+                        }]
+                    }
+                })
+            );
+            let payload = first_game_state_payload(&body);
+            assert_eq!(payload["game_state_type"], "GameStateType_Full");
+            assert_eq!(payload["type"], "game_state_message");
+        }
+
+        #[test]
+        fn test_game_state_type_diff_emits_string() {
+            let body = diff_game_state_message_body();
+            let payload = first_game_state_payload(&body);
+            assert_eq!(payload["game_state_type"], "GameStateType_Diff");
+            assert_eq!(payload["type"], "game_state_message");
+        }
+
+        #[test]
+        fn test_game_state_type_missing_emits_null() {
+            // game_state_message_body has no inner gameStateMessage.type field.
+            let body = game_state_message_body();
+            let payload = first_game_state_payload(&body);
+            assert!(
+                payload
+                    .get("game_state_type")
+                    .is_some_and(serde_json::Value::is_null),
+                "expected key present and JSON null, got {:?}",
+                payload.get("game_state_type")
+            );
+        }
+
+        #[test]
+        fn test_game_state_type_queued_variant_with_full_inner_type() {
+            let body = format!(
+                "[UnityCrossThreadLogger]greToClientEvent\n{}",
+                serde_json::json!({
+                    "greToClientEvent": {
+                        "greToClientMessages": [{
+                            "type": "GREMessageType_QueuedGameStateMessage",
+                            "msgId": 51,
+                            "gameStateId": 201,
+                            "gameStateMessage": {
+                                "type": "GameStateType_Full",
+                                "zones": [],
+                                "gameObjects": []
+                            }
+                        }]
+                    }
+                })
+            );
+            let payload = first_game_state_payload(&body);
+            assert_eq!(payload["type"], "queued_game_state_message");
+            assert_eq!(payload["game_state_type"], "GameStateType_Full");
+        }
     }
 }

--- a/src/parsers/gre/test_fixtures.rs
+++ b/src/parsers/gre/test_fixtures.rs
@@ -143,6 +143,39 @@ pub(super) fn game_state_message_body() -> String {
     )
 }
 
+/// Helper: build a `GameStateMessage` body with the inner
+/// `gameStateMessage.type` populated as `"GameStateType_Diff"`.
+///
+/// Mirrors `game_state_message_body` but tags the inner GSM as a Diff
+/// (incremental) update — used to exercise the `game_state_type`
+/// discriminator extraction.
+pub(super) fn diff_game_state_message_body() -> String {
+    format!(
+        "[UnityCrossThreadLogger]greToClientEvent\n{}",
+        serde_json::json!({
+            "greToClientEvent": {
+                "greToClientMessages": [{
+                    "type": "GREMessageType_GameStateMessage",
+                    "msgId": 6,
+                    "gameStateId": 43,
+                    "gameStateMessage": {
+                        "type": "GameStateType_Diff",
+                        "zones": [
+                            {
+                                "zoneId": 31,
+                                "type": "ZoneType_Hand",
+                                "ownerSeatId": 1,
+                                "objectInstanceIds": [201, 202]
+                            }
+                        ],
+                        "gameObjects": []
+                    }
+                }]
+            }
+        })
+    )
+}
+
 /// Helper: build a `QueuedGameStateMessage` body.
 pub(super) fn queued_game_state_message_body() -> String {
     format!(


### PR DESCRIPTION
## Summary
- Adds top-level `game_state_type` field to `game_state_message` and `queued_game_state_message` payloads, sourced verbatim from inner `gameStateMessage.type` (`"GameStateType_Full"` / `"GameStateType_Diff"`)
- Field is always present in the JSON; `None` serializes to `null` when the source is absent, so downstream consumers can rely on key presence
- Bumps version to `0.2.2` (additive non-breaking schema change)

## Changes Made
- `src/parsers/gre/game_state.rs`: extract inner `gsm["type"]` and emit immediately after the existing outer `"type"` field in the `serde_json::json!` builder; rustdoc shape example updated
- `src/parsers/gre/test_fixtures.rs`: new `diff_game_state_message_body()` shared fixture (no Diff-shaped fixture existed before)
- `src/parsers/gre/game_state.rs`: new `game_state_type_extraction` test submodule with 4 tests covering Full / Diff / missing / queued-with-Full
- `Cargo.toml` / `Cargo.lock`: version bump 0.2.1 → 0.2.2

## Testing
- All tests passing (1132 tests)
- Linting clean (`cargo clippy --all-targets --all-features -- -D warnings`), formatted
- Code coverage: 97.16% coverage, 1640/1688 lines covered (-0.05% — within noise; the new emit branch is fully covered by the 4 new tests)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)