### PR TITLE
Add make precommit contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
 
       - name: Pre-commit checks
-        run: make precommit
+        run: make -j precommit
 
   deny:
     name: cargo deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,8 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Clippy lint
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Run tests
-        run: cargo test --all-features
+      - name: Pre-commit checks
+        run: make precommit
 
   deny:
     name: cargo deny

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.2] - 2026-05-07
+
+### Changed
+
+- `Makefile` added with `precommit`, `precommit-trivial`, `coverage`, and `fmt` targets
+- CI `check` job updated to call `make precommit` instead of inlining gate steps
+- CLAUDE.md pre-commit checklist updated to reference `make precommit`
+
 ## [0.2.1] - 2026-04-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,14 +46,16 @@ cargo build
 
 ## 3. Pre-Commit Checklist (CRITICAL)
 
-- [ ] Code formatted: `cargo fmt --all`
-- [ ] Format verified: `cargo fmt --all -- --check`
-- [ ] Clippy clean: `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] Tests pass: `cargo test --all-features`
+- [ ] Pre-commit checks pass: `make precommit`
 - [ ] No `.unwrap()` in production code
 - [ ] No `dbg!()`, `todo!()`, or `println!()` in production code
 - [ ] **New/updated tests** for every code change
 - [ ] All files staged: `git add :/ && git status`
+
+Helpers (not gates):
+- `make fmt` auto-formats Rust code
+- `make precommit-trivial` runs the formatting floor only (used by /sequential-issues trivial-iteration skip)
+- `make coverage` runs `cargo tarpaulin` for coverage reporting
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# manasight-parser Makefile
+# Pre-commit contract for this repo.
+#
+# Targets:
+#   make precommit          Full pre-commit checklist (fmt check, clippy, tests).
+#   make precommit-trivial  Formatting floor only.
+#   make coverage           Tarpaulin coverage report.
+#   make fmt                Auto-format Rust code (helper, not a gate).
+
+.PHONY: precommit precommit-trivial coverage fmt
+
+precommit:
+	cargo fmt --all -- --check
+	cargo clippy --all-targets --all-features -- -D warnings
+	cargo test --all-features
+
+precommit-trivial:
+	cargo fmt --all -- --check
+
+coverage:
+	cargo tarpaulin --all-features --ignore-tests
+
+fmt:
+	cargo fmt --all


### PR DESCRIPTION
## Summary

Adds a `Makefile` exposing a standard pre-commit contract for this repo, plus the corresponding CI and `CLAUDE.md` updates.

## Changes

- New `Makefile` with `precommit`, `precommit-trivial`, `coverage`, and `fmt` targets.
- `.github/workflows/ci.yml`: collapses three inlined gate steps in the `check` job into a single `make precommit` step. The separate `deny` job is unchanged (license gating is not a precommit concern).
- `CLAUDE.md` Pre-Commit Checklist: machine-runnable commands replaced by `make precommit`. Human-review items (`.unwrap()`, all files staged, etc.) remain as separate bullets.

## Testing

- `make precommit` passes locally (1077 tests pass, clippy clean, fmt verified).
- `make precommit-trivial` runs `cargo fmt --check` only.
- `make coverage` invokes `cargo tarpaulin --all-features --ignore-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)