### PR TITLE
Fix #191: enable pipefail in smoke test step

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -100,6 +100,8 @@ jobs:
           MANASIGHT_TEST_LOGS: /tmp/test-logs/corpus
           CORPUS_TAG: ${{ steps.corpus-tag.outputs.tag }}
         run: |
+          # pipefail is load-bearing: without it, tee's exit 0 masks cargo test failures.
+          set -o pipefail
           set +e
           cargo test --all-features smoke_test_real_logs -- --nocapture 2>&1 | tee /tmp/smoke-output.txt
           SMOKE_EXIT=$?

--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -248,7 +248,7 @@
         "match_state": 3,
         "metadata": 1,
         "rank": 3,
-        "session": 999
+        "session": 2
       },
       "timestamp_failures": 112,
       "total_entries": 1843,

--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -248,7 +248,7 @@
         "match_state": 3,
         "metadata": 1,
         "rank": 3,
-        "session": 2
+        "session": 999
       },
       "timestamp_failures": 112,
       "total_entries": 1843,


### PR DESCRIPTION
## Summary

The `Run smoke tests` step in `.github/workflows/smoke-test.yml` was silently passing when `cargo test smoke_test_real_logs` panicked, because the cargo invocation is piped through `tee` and bash without `pipefail` captures `tee`'s exit code (always 0), not cargo's.

This PR adds `set -o pipefail` immediately before the existing `set +e`, so cargo's non-zero exit propagates through the pipeline. The rest of the step block (`SMOKE_EXIT` capture, `has_ratchet` grep, final `exit`) is preserved verbatim — those outputs are consumed by `Write job summary` (smoke-test.yml:177) and `Check for baseline improvements` (smoke-test.yml:203), and dropping them would silently disable the job summary rendering and the auto-baseline-update PR.

## Changes Made

- `.github/workflows/smoke-test.yml`: add `set -o pipefail` + a 1-line `# pipefail is load-bearing` comment, immediately before the existing `set +e`. No other changes.

## Testing

This is a CI workflow change — there is no application-code unit test that exercises shell pipeline semantics. Verification was done at the workflow level, per AC#2:

**Reproduce-and-verify (red CI proof):** A synthetic regression was committed mid-PR (and then reverted) to confirm the gate now correctly fires:

- **Red run (with perturbation):** https://github.com/manasight/manasight-parser/actions/runs/25835285613 — bumped `parsers.session` for the selesnya session from `2` to `999` in `smoke-baseline.json`. With `set -o pipefail` active, the ratchet regression panic at `tests/smoke_parsers.rs:704` propagated through `tee` and the job correctly reported FAILURE (exit 101). Log excerpt:
  ```
  Ratchet REGRESSIONS (1):
  thread 'smoke_test_real_logs' panicked at tests/smoke_parsers.rs:704:9:
  ratchet regressions detected (1 regression(s)) ...
  test smoke_test_real_logs ... FAILED
  ##[error]Process completed with exit code 101.
  ```
  Without the fix, this exact same panic would have produced `SMOKE_EXIT=0` and reported success.

- **Green run (perturbation reverted, workflow_dispatch on final commit):** https://github.com/manasight/manasight-parser/actions/runs/25835755772 — confirms the workflow still passes on clean state after the fix.

> Note: the AC's example suggested perturbing `total_entries`, but the ratchet (`tests/smoke_common/mod.rs:441`) compares per-parser claimed counts and per-event-type counts only — not `total_entries`. The verification commit bumped a per-parser count instead, which is what actually triggers a regression.

**Spot-check (AC#3):** Only `.github/workflows/smoke-test.yml` uses the `| tee` pattern in this repo. `.github/workflows/gitleaks.yml:25` and `.github/workflows/publish-crate.yml:34` already use `set -euo pipefail` defensively but have no pipes. `ci.yml`, `release.yml`, and `semgrep.yml` have no multi-line pipelines. No other workflows are affected.

Local pre-commit (`make precommit`) passed: 1077 unit tests pass, clippy clean, fmt clean.

## Test Justification

Per the repo's testing policy and the issue's AC, the only meaningful test for this change is observing the smoke-test workflow's CI behavior — there is no unit-testable surface for "bash pipefail propagates a child process's exit code." The synthetic-regression verification documented above is the equivalent of an integration test, and the workflow-run URLs are the audit trail.

## Coverage

Unchanged from main — no Rust code modified.

## Out of Scope

The bless-mode block at `smoke-test.yml:226` (`if ! cargo test ... 2>&1; then`) is a redirect, not a pipeline. Cargo's exit code already propagates correctly there; no change needed.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)
