### PR TITLE
chore: bump to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.2.2] - 2026-05-07
+## [0.3.0] - 2026-05-13
 
 ### Changed
 
-- `Makefile` added with `precommit`, `precommit-trivial`, `coverage`, and `fmt` targets
+- **`LineBuffer` now flushes multi-line entries on JSON brace-balance** instead of waiting for the next header (#193, #194). Entries containing a `{` are emitted the moment their JSON body's depth returns to 0, dropping draft-event and other interactive-flow latency from seconds-to-minutes to one polling cycle (~50 ms). Public method signatures are unchanged — but downstream consumers that previously batched entries between headers will now receive them sooner.
+- Non-JSON multi-line entries (`[Message summarized…]` GRE markers, `true`-bodied REST responses) keep the original "flush on next header" behavior as a deterministic fallback.
+
+### Added
+
+- New `brace_depth_flush` cargo feature, **default-on**, gating the new flush trigger. Disabling the feature reverts to the original next-header flush behavior — kept as a one-flip rollback in case a live-Arena edge case surfaces.
+- New `BraceState` internal struct with a string-literal + escape-aware state machine; handles nested-JSON-in-string values, escaped quotes, escaped backslashes, and brace noise inside string literals.
+- New `test-no-default-features` CI job (`.github/workflows/ci.yml`) so the rollback path cannot bit-rot.
+- `proptest = "1"` added to `[dev-dependencies]` for state-machine property tests (3 generators + 6 corpus-derived regression cases).
+
+### Fixed
+
+- Smoke-test CI step now uses `set -o pipefail` so failures inside the piped `cargo test … | tee` no longer silently pass (#191, #192).
+
+## [0.2.2] - 2026-05-07
+
+### Added
+
+- New `game_state_type` field on `game_state_message` and `queued_game_state_message` payloads, sourced from the inner `gameStateMessage.type` (`GameStateType_Full` / `GameStateType_Diff`). Field is always present — `None` serializes to JSON `null` — so the schema contract is unambiguous (#182, #183).
+
+### Changed
+
+- `Makefile` added with `precommit`, `precommit-trivial`, `coverage`, and `fmt` targets (#186)
 - CI `check` job updated to call `make precommit` instead of inlining gate steps
 - CLAUDE.md pre-commit checklist updated to reference `make precommit`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manasight-parser"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or in `Cargo.toml`:
 
 ```toml
 [dependencies]
-manasight-parser = "0.2"
+manasight-parser = "0.3"
 ```
 
 Requires Rust 1.93.0 or later.


### PR DESCRIPTION
## Summary

- Bump `manasight-parser` from **0.2.2 → 0.3.0** in preparation for the crates.io publish
- **Minor** bump rather than patch: public method signatures are unchanged, but `LineBuffer::push_line`'s entry-emission timing shifts from "on next header" to "on closing `}`" for JSON-bodied multi-line entries (#194). Downstream consumers may need to re-test their batching assumptions.
- v0.2.2 was pre-bumped in `Cargo.toml` back on May 6 (#183) but never tagged — its changes are folded into v0.3.0 and the CHANGELOG backfills 0.2.2 as historical record.

## Changes since v0.2.1

**Added**
- New `brace_depth_flush` cargo feature (default-on) — JSON brace-balance flush trigger for `LineBuffer` (#193, #194)
- New `BraceState` internal struct with string-literal + escape-aware state machine
- New `test-no-default-features` CI job so the rollback path can't bit-rot
- `proptest = "1"` in `[dev-dependencies]` for property tests
- New `game_state_type` field on `game_state_message` payloads (#182, #183)
- `Makefile` with `precommit`, `precommit-trivial`, `coverage`, `fmt` targets (#186)

**Changed**
- `LineBuffer` now flushes multi-line entries on JSON brace-balance instead of waiting for the next header. Non-JSON multi-line bodies keep the original behavior as a deterministic fallback.
- CI `check` job calls `make precommit` instead of inlining gate steps

**Fixed**
- Smoke-test CI step uses `set -o pipefail` so failures inside the piped `cargo test … | tee` no longer silently pass (#191, #192)

## Test plan

- [x] `cargo check` clean, `Cargo.lock` updated
- [x] `make precommit` clean locally (fmt + clippy + tests)
- [x] `cargo test --no-default-features` clean locally (rollback path)
- [ ] CI green on this PR
- [ ] After merge: tag `v0.3.0` and dispatch `publish-crate.yml --ref v0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)