### PR TITLE
Remove three zero-corpus-hit parser markers and dead code paths

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -517,8 +517,7 @@ define_event! {
 define_event! {
     /// Human draft pick events.
     ///
-    /// Parsed from `Draft.Notify`, `EventPlayerDraftMakePick`, and
-    /// `LogBusinessEvents` entries containing `PickGrpId`.
+    /// Parsed from `Draft.Notify` and `EventPlayerDraftMakePick`.
     DraftHumanEvent
 }
 
@@ -541,9 +540,8 @@ define_event! {
 define_event! {
     /// Session identity and connection events.
     ///
-    /// Covers `Updated account. DisplayName:`, `authenticateResponse`,
-    /// and `FrontDoorConnection.Close`. Needed to tag all subsequent events
-    /// with player identity.
+    /// Covers `authenticateResponse` and `FrontDoorConnection.Close`.
+    /// Needed to tag all subsequent events with player identity.
     SessionEvent
 }
 
@@ -978,9 +976,9 @@ mod tests {
     fn test_draft_human_event_field_access() {
         let event = DraftHumanEvent::new(
             make_metadata(b"human draft"),
-            serde_json::json!({"PickGrpId": 12345}),
+            serde_json::json!({"draft_id": "test-draft-123"}),
         );
-        assert_eq!(event.payload()["PickGrpId"], 12345);
+        assert_eq!(event.payload()["draft_id"], "test-draft-123");
     }
 
     #[test]

--- a/src/parsers/draft/human.rs
+++ b/src/parsers/draft/human.rs
@@ -1,19 +1,18 @@
 //! Human draft parser for Premier Draft and Traditional Draft events.
 //!
 //! In human (pod) drafts, the player drafts against other human players.
-//! Three log signatures capture the draft flow:
+//! Two log signatures capture the draft flow:
 //!
 //! | Signature | Meaning | Key Fields |
 //! |-----------|---------|------------|
 //! | `Draft.Notify` | Draft state notification (pack presented) | `draftId`, `SelfPack`, `SelfPick`, `PackCards` |
-//! | `EventPlayerDraftMakePick` | Player's pick selection | `EventName`, `PickInfo` with `CardId`, `PackNumber`, `PickNumber` |
-//! | `LogBusinessEvents` with `PickGrpId` | Pick confirmation (business event) | `PickGrpId`, `PackCards`, `EventName` |
+//! | `EventPlayerDraftMakePick` | Player's pick selection | `DraftId`, `GrpIds`, `Pack`, `Pick` |
 //!
 //! Human drafts have 3 packs of 14 picks each (42 total picks). Pack and
 //! pick numbers are zero-indexed in the log.
 //!
-//! All three events are Class 2 (Durable Per-Event) -- each pick is
-//! independently valuable and must survive crashes.
+//! Both events are Class 2 (Durable Per-Event) -- each pick is independently
+//! valuable and must survive crashes.
 
 use crate::events::{DraftHumanEvent, EventMetadata, GameEvent};
 use crate::log::entry::LogEntry;
@@ -31,23 +30,11 @@ const DRAFT_NOTIFY_MARKER: &str = "Draft.Notify";
 /// from the presented pack.
 const MAKE_PICK_MARKER: &str = "EventPlayerDraftMakePick";
 
-/// Marker that identifies business event entries in the log.
-///
-/// `LogBusinessEvents` is a shared container used for multiple event types
-/// (game results, draft picks, etc.). We further discriminate by checking
-/// for the `PickGrpId` field.
-const BUSINESS_EVENTS_MARKER: &str = "LogBusinessEvents";
-
-/// Field that distinguishes draft pick business events from other
-/// `LogBusinessEvents` entries (e.g., game results with `WinningType`).
-const PICK_GRP_ID_FIELD: &str = "PickGrpId";
-
 /// Attempts to parse a [`LogEntry`] as a human draft event.
 ///
 /// Returns `Some(GameEvent::DraftHuman(_))` if the entry matches any of:
 /// - A `Draft.Notify` pack presentation
 /// - An `EventPlayerDraftMakePick` pick selection
-/// - A `LogBusinessEvents` with `PickGrpId` pick confirmation
 ///
 /// Returns `None` if the entry does not match any human draft signature.
 ///
@@ -70,14 +57,6 @@ pub fn try_parse(
 
     // Try EventPlayerDraftMakePick (pick selection).
     if let Some(payload) = try_parse_make_pick(body) {
-        let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-        return Some(GameEvent::DraftHuman(DraftHumanEvent::new(
-            metadata, payload,
-        )));
-    }
-
-    // Try LogBusinessEvents with PickGrpId (pick confirmation).
-    if let Some(payload) = try_parse_pick_business_event(body) {
         let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
         return Some(GameEvent::DraftHuman(DraftHumanEvent::new(
             metadata, payload,
@@ -180,8 +159,7 @@ fn try_parse_make_pick(body: &str) -> Option<serde_json::Value> {
                 .and_then(|v| v.as_array())
                 .and_then(|arr| arr.first())
                 .and_then(serde_json::Value::as_i64)
-        })
-        .unwrap_or(0);
+        })?;
 
     let pack_idx = pick_info
         .get("PackNumber")
@@ -230,117 +208,6 @@ fn try_parse_make_pick(body: &str) -> Option<serde_json::Value> {
         "card_ids": card_ids,
         "raw_make_pick": parsed,
     }))
-}
-
-/// Attempts to parse a `LogBusinessEvents` with `PickGrpId` pick confirmation.
-///
-/// The log entry body contains a JSON object (or array of objects) with:
-/// - `PickGrpId`: the GRP ID of the picked card
-/// - `PackCards`: card GRP IDs that were in the pack (may be comma-separated
-///   string or array)
-/// - `EventName` or `InternalEventName`: the Arena event identifier
-fn try_parse_pick_business_event(body: &str) -> Option<serde_json::Value> {
-    // Must contain both the business events marker and PickGrpId.
-    if !body.contains(BUSINESS_EVENTS_MARKER) {
-        return None;
-    }
-
-    if !body.contains(PICK_GRP_ID_FIELD) {
-        return None;
-    }
-
-    let parsed = api_common::parse_json_from_body(body, "LogBusinessEvents (draft pick)")?;
-
-    // Find the source object containing PickGrpId.
-    let source = find_pick_source(&parsed)?;
-
-    let pick_grp_id = source
-        .get("PickGrpId")
-        .and_then(serde_json::Value::as_i64)
-        .unwrap_or(0);
-
-    let pack_cards = extract_business_event_pack_cards(source);
-
-    let event_name = source
-        .get("EventName")
-        .or_else(|| source.get("InternalEventName"))
-        .or_else(|| parsed.get("EventName"))
-        .or_else(|| parsed.get("InternalEventName"))
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("");
-
-    let pack_idx = source
-        .get("PackNumber")
-        .and_then(serde_json::Value::as_i64)
-        .unwrap_or(0);
-
-    let selection_idx = source
-        .get("PickNumber")
-        .and_then(serde_json::Value::as_i64)
-        .unwrap_or(0);
-
-    Some(serde_json::json!({
-        "type": "draft_human_pick_confirm",
-        "pick_grp_id": pick_grp_id,
-        "pack_cards": pack_cards,
-        "event_name": event_name,
-        "pack_number": pack_idx,
-        "pick_number": selection_idx,
-        "raw_business_event": parsed,
-    }))
-}
-
-/// Finds the source object containing `PickGrpId` within a parsed JSON value.
-///
-/// Searches the top level, inside a `Params` object, and inside a
-/// top-level array of business events.
-fn find_pick_source(parsed: &serde_json::Value) -> Option<&serde_json::Value> {
-    // Top level.
-    if parsed.get(PICK_GRP_ID_FIELD).is_some() {
-        return Some(parsed);
-    }
-
-    // Inside a `Params` object.
-    if let Some(params) = parsed.get("Params") {
-        if params.get(PICK_GRP_ID_FIELD).is_some() {
-            return Some(params);
-        }
-    }
-
-    // Inside a top-level array of business events.
-    if let Some(arr) = parsed.as_array() {
-        return arr
-            .iter()
-            .find(|item| item.get(PICK_GRP_ID_FIELD).is_some());
-    }
-
-    None
-}
-
-/// Extracts pack card IDs from a `PackCards` field in a business event.
-///
-/// `PackCards` may be a comma-separated string of GRP IDs (e.g., `"12345,67890"`)
-/// or an array of integers. This function normalizes to `Vec<i64>`.
-fn extract_business_event_pack_cards(source: &serde_json::Value) -> Vec<i64> {
-    if let Some(pack_cards) = source.get("PackCards") {
-        // Try as comma-separated string first.
-        if let Some(s) = pack_cards.as_str() {
-            return parse_comma_separated_ids(s);
-        }
-
-        // Try as array.
-        if let Some(arr) = pack_cards.as_array() {
-            return arr
-                .iter()
-                .filter_map(|v| {
-                    v.as_i64()
-                        .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
-                })
-                .collect();
-        }
-    }
-
-    Vec::new()
 }
 
 /// Extracts pack card IDs from a `PackCards` field in a `Draft.Notify` payload.
@@ -668,7 +535,7 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_make_pick_missing_card_id_defaults_to_zero() {
+        fn test_try_parse_make_pick_missing_card_id_returns_none() {
             let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
                          {\n\
                            \"PickInfo\": {\n\
@@ -679,11 +546,7 @@ mod tests {
             let entry = unity_entry(body);
             let result = try_parse(&entry, Some(test_timestamp()));
 
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = draft_human_payload(event);
-
-            assert_eq!(payload["card_id"], 0);
+            assert!(result.is_none());
         }
 
         #[test]
@@ -766,155 +629,6 @@ mod tests {
         }
     }
 
-    // -- LogBusinessEvents with PickGrpId parsing ----------------------------
-
-    mod pick_business_event {
-        use super::*;
-
-        #[test]
-        fn test_try_parse_pick_business_event_basic() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         {\n\
-                           \"PickGrpId\": 12345,\n\
-                           \"PackCards\": \"12345,67890,11111\",\n\
-                           \"EventName\": \"PremierDraft_MKM_20260201\"\n\
-                         }";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = draft_human_payload(event);
-
-            assert_eq!(payload["type"], "draft_human_pick_confirm");
-            assert_eq!(payload["pick_grp_id"], 12345);
-            assert_eq!(
-                payload["pack_cards"],
-                serde_json::json!([12345, 67890, 11111])
-            );
-            assert_eq!(payload["event_name"], "PremierDraft_MKM_20260201");
-        }
-
-        #[test]
-        fn test_try_parse_pick_business_event_with_pack_pick_numbers() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         {\n\
-                           \"PickGrpId\": 67890,\n\
-                           \"PackNumber\": 1,\n\
-                           \"PickNumber\": 5,\n\
-                           \"PackCards\": \"67890,22222\"\n\
-                         }";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = draft_human_payload(event);
-
-            assert_eq!(payload["pick_grp_id"], 67890);
-            assert_eq!(payload["pack_number"], 1);
-            assert_eq!(payload["pick_number"], 5);
-        }
-
-        #[test]
-        fn test_try_parse_pick_business_event_params_wrapper() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         {\n\
-                           \"Params\": {\n\
-                             \"PickGrpId\": 33333,\n\
-                             \"PackCards\": \"33333,44444,55555\"\n\
-                           }\n\
-                         }";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = draft_human_payload(event);
-
-            assert_eq!(payload["pick_grp_id"], 33333);
-            assert_eq!(
-                payload["pack_cards"],
-                serde_json::json!([33333, 44444, 55555])
-            );
-        }
-
-        #[test]
-        fn test_try_parse_pick_business_event_array_format() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         [\n\
-                           {\"SomeOtherField\": \"value\"},\n\
-                           {\n\
-                             \"PickGrpId\": 44444,\n\
-                             \"PackCards\": \"44444,55555\"\n\
-                           }\n\
-                         ]";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = draft_human_payload(event);
-
-            assert_eq!(payload["pick_grp_id"], 44444);
-        }
-
-        #[test]
-        fn test_try_parse_pick_business_event_array_pack_cards() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         {\n\
-                           \"PickGrpId\": 12345,\n\
-                           \"PackCards\": [12345, 67890, 11111]\n\
-                         }";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = draft_human_payload(event);
-
-            assert_eq!(
-                payload["pack_cards"],
-                serde_json::json!([12345, 67890, 11111])
-            );
-        }
-
-        #[test]
-        fn test_try_parse_pick_business_event_preserves_raw_payload() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         {\n\
-                           \"PickGrpId\": 12345,\n\
-                           \"ExtraField\": \"preserved\"\n\
-                         }";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = draft_human_payload(event);
-
-            assert_eq!(payload["raw_business_event"]["ExtraField"], "preserved");
-        }
-
-        #[test]
-        fn test_try_parse_pick_business_event_with_timestamp_in_header() {
-            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM \
-                         LogBusinessEvents\n\
-                         {\n\
-                           \"PickGrpId\": 88888,\n\
-                           \"PackCards\": \"88888\"\n\
-                         }";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = draft_human_payload(event);
-
-            assert_eq!(payload["pick_grp_id"], 88888);
-        }
-    }
-
     // -- Metadata preservation -----------------------------------------------
 
     mod metadata {
@@ -947,18 +661,6 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_preserves_raw_bytes_business_event() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         {\"PickGrpId\": 12345}";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
-        }
-
-        #[test]
         fn test_try_parse_stores_timestamp_notify() {
             let body = "[UnityCrossThreadLogger]Draft.Notify\n\
                          {\"SelfPack\": 0, \"SelfPick\": 0, \
@@ -977,19 +679,6 @@ mod tests {
             let body = "[UnityCrossThreadLogger]EventPlayerDraftMakePick\n\
                          {\"PickInfo\": {\"CardId\": 1, \"PackNumber\": 0, \
                           \"PickNumber\": 0}}";
-            let entry = unity_entry(body);
-            let ts = Some(test_timestamp());
-            let result = try_parse(&entry, ts);
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert_eq!(event.metadata().timestamp(), ts);
-        }
-
-        #[test]
-        fn test_try_parse_stores_timestamp_business_event() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         {\"PickGrpId\": 12345}";
             let entry = unity_entry(body);
             let ts = Some(test_timestamp());
             let result = try_parse(&entry, ts);
@@ -1134,18 +823,6 @@ mod tests {
             let event = result.as_ref().unwrap_or_else(|| unreachable!());
             assert_eq!(event.performance_class(), PerformanceClass::DurablePerEvent);
         }
-
-        #[test]
-        fn test_draft_human_business_event_is_durable_per_event() {
-            let body = "[UnityCrossThreadLogger]LogBusinessEvents\n\
-                         {\"PickGrpId\": 12345}";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert_eq!(event.performance_class(), PerformanceClass::DurablePerEvent);
-        }
     }
 
     // -- Internal helpers ----------------------------------------------------
@@ -1186,33 +863,6 @@ mod tests {
                 parse_comma_separated_ids("12345,abc,67890"),
                 vec![12345, 67890]
             );
-        }
-
-        #[test]
-        fn test_find_pick_source_top_level() {
-            let val = serde_json::json!({"PickGrpId": 12345});
-            assert!(find_pick_source(&val).is_some());
-        }
-
-        #[test]
-        fn test_find_pick_source_in_params() {
-            let val = serde_json::json!({"Params": {"PickGrpId": 12345}});
-            assert!(find_pick_source(&val).is_some());
-        }
-
-        #[test]
-        fn test_find_pick_source_in_array() {
-            let val = serde_json::json!([
-                {"SomeField": 1},
-                {"PickGrpId": 12345}
-            ]);
-            assert!(find_pick_source(&val).is_some());
-        }
-
-        #[test]
-        fn test_find_pick_source_absent() {
-            let val = serde_json::json!({"WinningType": "WinLoss"});
-            assert!(find_pick_source(&val).is_none());
         }
     }
 }

--- a/src/parsers/draft/mod.rs
+++ b/src/parsers/draft/mod.rs
@@ -5,7 +5,7 @@
 //! | Module | Log Signatures | Event Type |
 //! |--------|---------------|------------|
 //! | [`bot`] | `BotDraftDraftStatus`, `BotDraftDraftPick` | [`DraftBotEvent`](crate::events::DraftBotEvent) |
-//! | [`human`] | `Draft.Notify`, `EventPlayerDraftMakePick`, `LogBusinessEvents` with `PickGrpId` | [`DraftHumanEvent`](crate::events::DraftHumanEvent) |
+//! | [`human`] | `Draft.Notify`, `EventPlayerDraftMakePick` | [`DraftHumanEvent`](crate::events::DraftHumanEvent) |
 //! | [`complete`] | `DraftCompleteDraft` | [`DraftCompleteEvent`](crate::events::DraftCompleteEvent) |
 
 pub mod bot;

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -445,7 +445,7 @@ mod tests {
 
         #[test]
         fn test_try_parse_unrelated_entry_returns_empty() {
-            let body = "[UnityCrossThreadLogger]Updated account. DisplayName:Test";
+            let body = "[UnityCrossThreadLogger]FrontDoorConnection.Close";
             let entry = unity_entry(body);
             assert!(try_parse(&entry, Some(test_timestamp())).is_empty());
         }

--- a/src/parsers/match_state.rs
+++ b/src/parsers/match_state.rs
@@ -681,8 +681,8 @@ mod tests {
 
         #[test]
         fn test_try_parse_session_event_returns_none() {
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:Test, AccountID:abc123";
+            let body = "[UnityCrossThreadLogger]authenticateResponse\n\
+                         {\"screenName\":\"Test\"}";
             let entry = unity_entry(body);
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }

--- a/src/parsers/session.rs
+++ b/src/parsers/session.rs
@@ -1,11 +1,10 @@
-//! Session event parser: login, account ID, display name, and logout.
+//! Session event parser: login and logout.
 //!
-//! Recognizes three log signatures that establish and terminate player
+//! Recognizes two log signatures that establish and terminate player
 //! identity within a session:
 //!
 //! | Signature | Meaning |
 //! |-----------|---------|
-//! | `Updated account. DisplayName:` | Account identity (display name + account ID) |
 //! | `authenticateResponse` | Login confirmation (screen name in JSON) |
 //! | `FrontDoorConnection.Close` | Logout / disconnect |
 //!
@@ -15,9 +14,6 @@
 use crate::events::{EventMetadata, GameEvent, SessionEvent};
 use crate::log::entry::LogEntry;
 use crate::parsers::api_common;
-
-/// Prefix that introduces account identity lines in the log.
-const ACCOUNT_UPDATE_PREFIX: &str = "Updated account. DisplayName:";
 
 /// Marker for authentication response entries.
 const AUTHENTICATE_RESPONSE_MARKER: &str = "authenticateResponse";
@@ -43,11 +39,6 @@ pub fn try_parse(
     // Strip the header prefix (e.g., "[UnityCrossThreadLogger]") to get
     // the content portion of the first line.
     let content = strip_header_prefix(body);
-
-    if let Some(payload) = try_parse_account_update(content) {
-        let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-        return Some(GameEvent::Session(SessionEvent::new(metadata, payload)));
-    }
 
     if let Some(payload) = try_parse_authenticate_response(body) {
         let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
@@ -78,38 +69,6 @@ fn strip_header_prefix(body: &str) -> &str {
     } else {
         first_line
     }
-}
-
-/// Attempts to parse an `Updated account. DisplayName:` line.
-///
-/// Expected format (after header stripping):
-/// ```text
-/// Updated account. DisplayName:SomeName, AccountID:abc123def456, ...
-/// ```
-///
-/// Extracts `DisplayName` and `AccountID` fields and returns them as a
-/// JSON payload with `type: "session_account_update"`.
-fn try_parse_account_update(content: &str) -> Option<serde_json::Value> {
-    if !content.contains(ACCOUNT_UPDATE_PREFIX) {
-        return None;
-    }
-
-    // Extract text after "DisplayName:" up to the next comma or end of line.
-    let after_prefix = content.split(ACCOUNT_UPDATE_PREFIX).nth(1)?;
-    let display_name = after_prefix.split(',').next().unwrap_or("").trim();
-
-    // Extract AccountID if present.
-    let account_id = content
-        .split("AccountID:")
-        .nth(1)
-        .and_then(|s| s.split(',').next())
-        .map_or("", str::trim);
-
-    Some(serde_json::json!({
-        "type": "session_account_update",
-        "display_name": display_name,
-        "account_id": account_id,
-    }))
 }
 
 /// Attempts to parse an `authenticateResponse` entry.
@@ -192,120 +151,6 @@ fn find_screen_name(value: &serde_json::Value) -> Option<String> {
 mod tests {
     use super::*;
     use crate::parsers::test_helpers::{session_payload, test_timestamp, unity_entry, EntryHeader};
-
-    // -- Account update parsing -----------------------------------------------
-
-    mod account_update {
-        use super::*;
-
-        #[test]
-        fn test_try_parse_account_update_basic() {
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:TestPlayer, \
-                         AccountID:abcdef123456, \
-                         Token:sometoken123";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| {
-                // Safe: we just asserted is_some() above.
-                unreachable!()
-            });
-            let payload = session_payload(event);
-
-            assert_eq!(payload["type"], "session_account_update");
-            assert_eq!(payload["display_name"], "TestPlayer");
-            assert_eq!(payload["account_id"], "abcdef123456");
-        }
-
-        #[test]
-        fn test_try_parse_account_update_with_space_after_header() {
-            let body = "[UnityCrossThreadLogger] Updated account. \
-                         DisplayName:Player Two, \
-                         AccountID:xyz789";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = session_payload(event);
-
-            assert_eq!(payload["type"], "session_account_update");
-            assert_eq!(payload["display_name"], "Player Two");
-            assert_eq!(payload["account_id"], "xyz789");
-        }
-
-        #[test]
-        fn test_try_parse_account_update_empty_display_name() {
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:, AccountID:abc123";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = session_payload(event);
-
-            assert_eq!(payload["display_name"], "");
-            assert_eq!(payload["account_id"], "abc123");
-        }
-
-        #[test]
-        fn test_try_parse_account_update_no_account_id() {
-            let body = "[UnityCrossThreadLogger]Updated account. DisplayName:Solo";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = session_payload(event);
-
-            assert_eq!(payload["display_name"], "Solo");
-            assert_eq!(payload["account_id"], "");
-        }
-
-        #[test]
-        fn test_try_parse_account_update_preserves_raw_bytes() {
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:RawTest, AccountID:raw123";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert_eq!(event.metadata().raw_bytes(), body.as_bytes());
-        }
-
-        #[test]
-        fn test_try_parse_account_update_stores_timestamp() {
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:TsTest, AccountID:ts123";
-            let entry = unity_entry(body);
-            let ts = Some(test_timestamp());
-            let result = try_parse(&entry, ts);
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            assert_eq!(event.metadata().timestamp(), ts);
-        }
-
-        #[test]
-        fn test_try_parse_account_update_with_timestamp_in_header() {
-            let body = "[UnityCrossThreadLogger]2/25/2026 12:00:00 PM \
-                         Updated account. DisplayName:TimestampPlayer, \
-                         AccountID:ts456";
-            let entry = unity_entry(body);
-            let result = try_parse(&entry, Some(test_timestamp()));
-
-            assert!(result.is_some());
-            let event = result.as_ref().unwrap_or_else(|| unreachable!());
-            let payload = session_payload(event);
-
-            assert_eq!(payload["display_name"], "TimestampPlayer");
-            assert_eq!(payload["account_id"], "ts456");
-        }
-    }
 
     // -- Authenticate response parsing ----------------------------------------
 
@@ -501,13 +346,6 @@ mod tests {
             let entry = unity_entry(body);
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }
-
-        #[test]
-        fn test_try_parse_partial_account_marker_returns_none() {
-            let body = "[UnityCrossThreadLogger]Updated account status";
-            let entry = unity_entry(body);
-            assert!(try_parse(&entry, Some(test_timestamp())).is_none());
-        }
     }
 
     // -- Performance class ---------------------------------------------------
@@ -518,8 +356,8 @@ mod tests {
 
         #[test]
         fn test_session_event_is_durable_per_event() {
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:ClassTest, AccountID:class123";
+            let body = "[UnityCrossThreadLogger]authenticateResponse\n\
+                         {\"screenName\":\"ClassTest\"}";
             let entry = unity_entry(body);
             let result = try_parse(&entry, Some(test_timestamp()));
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -396,7 +396,7 @@ mod tests {
 
         #[test]
         fn test_extract_timestamp_no_timestamp_content_returns_none() {
-            let body = "[UnityCrossThreadLogger]Updated account. DisplayName:Player";
+            let body = "[UnityCrossThreadLogger]FrontDoorConnection.Close";
             let ts = extract_timestamp(body);
             assert!(ts.is_none());
         }
@@ -498,12 +498,10 @@ mod tests {
         }
 
         #[test]
-        fn test_route_session_account_update() {
+        fn test_route_session_authenticate_response() {
             let router = Router::new();
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:TestPlayer, \
-                         AccountID:abc123, \
-                         Token:sometoken";
+            let body = "[UnityCrossThreadLogger]authenticateResponse\n\
+                         {\"screenName\":\"TestPlayer\"}";
             let entry = unity_entry(body);
 
             let results = router.route(&entry);
@@ -703,10 +701,8 @@ mod tests {
         fn test_route_no_timestamp_session_still_routes() {
             let router = Router::new();
             // Real-world session entries without timestamps should still route.
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:Player, \
-                         AccountID:abc123, \
-                         Token:token";
+            let body = "[UnityCrossThreadLogger]authenticateResponse\n\
+                         {\"screenName\":\"Player\"}";
             let entry = unity_entry(body);
 
             let results = router.route(&entry);
@@ -722,10 +718,8 @@ mod tests {
             let router = Router::new();
             // Session entries without timestamps should have None timestamp
             // in metadata rather than a synthetic Utc::now().
-            let body = "[UnityCrossThreadLogger]Updated account. \
-                         DisplayName:Player, \
-                         AccountID:abc123, \
-                         Token:token";
+            let body = "[UnityCrossThreadLogger]authenticateResponse\n\
+                         {\"screenName\":\"Player\"}";
             let entry = unity_entry(body);
 
             let results = router.route(&entry);
@@ -800,10 +794,8 @@ mod tests {
             let router = Router::new();
 
             // Route one known entry (session -- no timestamp in header).
-            let known_body = "[UnityCrossThreadLogger]Updated account. \
-                              DisplayName:Player, \
-                              AccountID:abc123, \
-                              Token:token";
+            let known_body = "[UnityCrossThreadLogger]authenticateResponse\n\
+                              {\"screenName\":\"Player\"}";
             router.route(&unity_entry(known_body));
 
             // Route one unknown entry (with valid timestamp).

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -352,10 +352,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_delivers_session_event() -> TestResult {
-        let content = "[UnityCrossThreadLogger]Updated account. \
-                        DisplayName:TestPlayer, \
-                        AccountID:abc123, \
-                        Token:sometoken\n\
+        let content = "[UnityCrossThreadLogger]authenticateResponse\n\
+                        {\"screenName\":\"TestPlayer\"}\n\
                         [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
                         some filler\n";
         let f = temp_log(content)?;
@@ -418,10 +416,8 @@ mod tests {
             }
         });
         let content = format!(
-            "[UnityCrossThreadLogger]Updated account. \
-             DisplayName:TestPlayer, \
-             AccountID:abc123, \
-             Token:sometoken\n\
+            "[UnityCrossThreadLogger]authenticateResponse\n\
+             {{\"screenName\":\"TestPlayer\"}}\n\
              [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n{gs_payload}\n\
              [UnityCrossThreadLogger]2/25/2026 12:00:01 PM\nfiller\n"
         );
@@ -463,10 +459,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_once_delivers_session_event() -> TestResult {
-        let content = "[UnityCrossThreadLogger]Updated account. \
-                        DisplayName:TestPlayer, \
-                        AccountID:abc123, \
-                        Token:sometoken\n\
+        let content = "[UnityCrossThreadLogger]authenticateResponse\n\
+                        {\"screenName\":\"TestPlayer\"}\n\
                         [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
                         some filler\n";
         let f = temp_log(content)?;
@@ -484,10 +478,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_once_subscriber_ends_after_eof() -> TestResult {
-        let content = "[UnityCrossThreadLogger]Updated account. \
-                        DisplayName:TestPlayer, \
-                        AccountID:abc123, \
-                        Token:sometoken\n\
+        let content = "[UnityCrossThreadLogger]authenticateResponse\n\
+                        {\"screenName\":\"TestPlayer\"}\n\
                         [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
                         some filler\n";
         let f = temp_log(content)?;
@@ -561,10 +553,8 @@ mod tests {
     #[tokio::test]
     async fn test_start_emits_log_file_rotated_event_on_rotation() -> TestResult {
         // Create initial log with enough content to set a non-zero offset.
-        let initial = "[UnityCrossThreadLogger]Updated account. \
-                        DisplayName:TestPlayer, \
-                        AccountID:abc123, \
-                        Token:sometoken\n\
+        let initial = "[UnityCrossThreadLogger]authenticateResponse\n\
+                        {\"screenName\":\"TestPlayer\"}\n\
                         [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
                         some filler\n";
         let f = temp_log(initial)?;
@@ -641,10 +631,8 @@ mod tests {
     #[tokio::test]
     async fn test_start_once_detailed_logs_enabled() -> TestResult {
         let content = "DETAILED LOGS: ENABLED\n\
-                        [UnityCrossThreadLogger]Updated account. \
-                        DisplayName:TestPlayer, \
-                        AccountID:abc123, \
-                        Token:sometoken\n\
+                        [UnityCrossThreadLogger]authenticateResponse\n\
+                        {\"screenName\":\"TestPlayer\"}\n\
                         [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n\
                         some filler\n";
         let f = temp_log(content)?;

--- a/tests/stream_integration.rs
+++ b/tests/stream_integration.rs
@@ -27,10 +27,8 @@ fn temp_log(content: &str) -> Result<NamedTempFile, std::io::Error> {
 
 #[tokio::test]
 async fn test_stream_session_event_from_log_file() -> TestResult {
-    let content = "[UnityCrossThreadLogger]Updated account. \
-                    DisplayName:TestPlayer, \
-                    AccountID:abc123, \
-                    Token:sometoken\n\
+    let content = "[UnityCrossThreadLogger]authenticateResponse\n\
+                    {\"screenName\":\"TestPlayer\"}\n\
                     [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\nfiller\n";
     let f = temp_log(content)?;
 
@@ -96,10 +94,8 @@ async fn test_stream_multiple_event_types_in_order() -> TestResult {
     });
     // Session event (no timestamp) followed by GameState event (with timestamp).
     let content = format!(
-        "[UnityCrossThreadLogger]Updated account. \
-         DisplayName:TestPlayer, \
-         AccountID:abc123, \
-         Token:sometoken\n\
+        "[UnityCrossThreadLogger]authenticateResponse\n\
+         {{\"screenName\":\"TestPlayer\"}}\n\
          [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n{gs_payload}\n\
          [UnityCrossThreadLogger]2/25/2026 12:00:01 PM\nfiller\n"
     );
@@ -210,10 +206,8 @@ async fn test_stream_subscriber_ends_after_shutdown() -> TestResult {
 #[tokio::test]
 async fn test_stream_detailed_logs_enabled_event() -> TestResult {
     let content = "DETAILED LOGS: ENABLED\n\
-                    [UnityCrossThreadLogger]Updated account. \
-                    DisplayName:TestPlayer, \
-                    AccountID:abc123, \
-                    Token:sometoken\n\
+                    [UnityCrossThreadLogger]authenticateResponse\n\
+                    {\"screenName\":\"TestPlayer\"}\n\
                     [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\nfiller\n";
     let f = temp_log(content)?;
 


### PR DESCRIPTION
## Summary

Corpus audit (manasight/manasight-parser#157) confirmed three marker constants with **zero occurrences** across all 27 corpus sessions. This PR removes the dead code following the same pattern as #149 and #156.

**Removed:**
- `Updated account. DisplayName:` (`ACCOUNT_UPDATE_PREFIX`) + `try_parse_account_update` in `session.rs` — 0 corpus hits; `authenticateResponse` (105 hits) is the real identity source
- `LogBusinessEvents` (`BUSINESS_EVENTS_MARKER`) + `PickGrpId` (`PICK_GRP_ID_FIELD`) + `try_parse_pick_business_event` / `find_pick_source` / `extract_business_event_pack_cards` in `draft/human.rs` — 0 corpus hits

**Also fixed:**
- `.unwrap_or(0)` → `?` for `card_id` extraction in `try_parse_make_pick` (same silent-zero bug fixed on the bot side in #156, deferred to this audit per #157 comment)

**Test fixtures** that used `Updated account. DisplayName:` as a mock session entry are updated to `authenticateResponse` format, which matches what real logs actually emit.

## Audit results (all 57 markers checked)

| Marker | Corpus hits | Disposition |
|--------|-------------|-------------|
| `Updated account. DisplayName:` | **0** | Removed |
| `LogBusinessEvents` | **0** | Removed |
| `PickGrpId` | **0** | Removed |
| All other markers | 1–21387 | Kept |

## Test plan

- [x] `cargo check --all-features` — clean
- [x] `cargo test --all-features` — all tests pass (net -540 lines)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)