### PR TITLE
Remove dead EntryHeader::ClientGre variant (#207)

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -211,7 +211,7 @@ pub enum GameEvent {
     /// Emitted by the file tailer when it determines whether Arena's
     /// "Detailed Logs (Plugin Support)" setting is enabled. `enabled: false`
     /// is emitted after 30 seconds of observed log writes without any
-    /// `[UnityCrossThreadLogger]` or `[Client GRE]` headers. `enabled: true`
+    /// `[UnityCrossThreadLogger]` headers. `enabled: true`
     /// is emitted if structured headers are later detected (user enabled the
     /// setting and restarted Arena).
     /// Class 1 — interactive dispatch (local status signal).
@@ -577,10 +577,11 @@ define_event! {
 define_event! {
     /// Game result event — triggers post-game batch assembly.
     ///
-    /// Parsed from `LogBusinessEvents` with `WinningType` and
-    /// `GameStage_GameOver`. When this event fires, the desktop app
-    /// serializes the disk-backed game buffer into a single compressed
-    /// payload and uploads it.
+    /// Parsed from a GRE `GameStateMessage` whose `gameInfo.stage` equals
+    /// `GameStage_GameOver` (specifically the `MatchState_GameComplete`
+    /// variant to avoid duplicate firing in Bo3). When this event fires,
+    /// the desktop app serializes the disk-backed game buffer into a single
+    /// compressed payload and uploads it.
     GameResultEvent
 }
 

--- a/src/log/entry.rs
+++ b/src/log/entry.rs
@@ -1,7 +1,7 @@
 //! Log entry prefix identification and multi-line JSON accumulation.
 //!
 //! Detects log entry boundaries using the `[UnityCrossThreadLogger]`,
-//! `[Client GRE]`, `[ConnectionManager]`, and `Matchmaking:` header patterns,
+//! `[ConnectionManager]`, and `Matchmaking:` header patterns,
 //! then accumulates subsequent lines until the entry is structurally complete.
 //!
 //! # Header classification (Phase 1 of #153)
@@ -15,10 +15,9 @@
 //!   flushed in the same [`LineBuffer::push_line`] call that received them
 //!   — no continuation accumulation.
 //! - **Multi-line**: `[UnityCrossThreadLogger]<digit>` (date-prefixed API
-//!   responses, match events) and `[Client GRE]…`. These entries
-//!   accumulate continuation lines until the entry's JSON body is
-//!   structurally complete (brace-balance flush) or the next header arrives
-//!   (fallback for non-JSON bodies).
+//!   responses, match events). These entries accumulate continuation lines
+//!   until the entry's JSON body is structurally complete (brace-balance
+//!   flush) or the next header arrives (fallback for non-JSON bodies).
 //!
 //! # Brace-balance flush (Phase 3 of #153 / #193)
 //!
@@ -71,8 +70,6 @@ pub enum EntryHeader {
     /// `[UnityCrossThreadLogger]` — the most common header, used for
     /// game state, client actions, match lifecycle, and most other events.
     UnityCrossThreadLogger,
-    /// `[Client GRE]` — used for Game Rules Engine messages.
-    ClientGre,
     /// `[ConnectionManager]` — emitted for Arena's connection-lifecycle
     /// diagnostics (e.g., `Reconnect result : ...`, `Reconnect succeeded`,
     /// `Reconnect failed`). These lines are plain-text, single-line entries
@@ -108,7 +105,6 @@ impl EntryHeader {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::UnityCrossThreadLogger => "[UnityCrossThreadLogger]",
-            Self::ClientGre => "[Client GRE]",
             Self::ConnectionManager => "[ConnectionManager]",
             Self::Matchmaking => "Matchmaking:",
             Self::Metadata => "METADATA",
@@ -259,11 +255,10 @@ impl LineBuffer {
         // The regex crate documents that `Regex::new` only fails on invalid
         // patterns. This pattern is a compile-time constant and is valid, so
         // the `Err` branch is unreachable in practice.
-        let header_re =
-            match Regex::new(r"^\[(UnityCrossThreadLogger|Client GRE|ConnectionManager)\]") {
-                Ok(re) => re,
-                Err(e) => unreachable!("invalid header regex: {e}"),
-            };
+        let header_re = match Regex::new(r"^\[(UnityCrossThreadLogger|ConnectionManager)\]") {
+            Ok(re) => re,
+            Err(e) => unreachable!("invalid header regex: {e}"),
+        };
         Self {
             header_re,
             current_header: None,
@@ -286,7 +281,7 @@ impl LineBuffer {
     /// headers (`[UnityCrossThreadLogger]<non-digit>`, `[ConnectionManager]…`,
     /// `Matchmaking:…`) flush any prior multi-line entry and emit the new
     /// entry in the same call. Multi-line headers
-    /// (`[UnityCrossThreadLogger]<digit>`, `[Client GRE]…`) flush any prior
+    /// (`[UnityCrossThreadLogger]<digit>`) flush any prior
     /// entry and begin a fresh accumulation.
     ///
     /// Metadata lines (`DETAILED LOGS: ENABLED` / `DISABLED`) are
@@ -421,8 +416,8 @@ impl LineBuffer {
 
     /// Detects whether `line` starts with a known header prefix.
     ///
-    /// Bracketed headers (`[UnityCrossThreadLogger]`, `[Client GRE]`,
-    /// `[ConnectionManager]`) are matched via the compiled regex. The
+    /// Bracketed headers (`[UnityCrossThreadLogger]`, `[ConnectionManager]`)
+    /// are matched via the compiled regex. The
     /// bare `Matchmaking: ` prefix is matched via a separate
     /// `starts_with` check because it has no brackets.
     fn detect_header(&self, line: &str) -> Option<EntryHeader> {
@@ -430,7 +425,6 @@ impl LineBuffer {
             let prefix = caps.get(1)?.as_str();
             return match prefix {
                 "UnityCrossThreadLogger" => Some(EntryHeader::UnityCrossThreadLogger),
-                "Client GRE" => Some(EntryHeader::ClientGre),
                 "ConnectionManager" => Some(EntryHeader::ConnectionManager),
                 _ => None,
             };
@@ -453,8 +447,6 @@ impl LineBuffer {
     ///   (date-prefixed API responses and match events).
     /// - `[UnityCrossThreadLogger]` followed by anything else → single-line
     ///   (alpha labels and `==>` request markers).
-    /// - `[Client GRE]` → multi-line (current behavior preserved; corpus
-    ///   has zero coverage of this header).
     /// - `[ConnectionManager]…` → single-line.
     /// - `Matchmaking:…` → single-line.
     fn classify_header(header: EntryHeader, line: &str) -> HeaderClass {
@@ -470,16 +462,13 @@ impl LineBuffer {
                     HeaderClass::SingleLine
                 }
             }
-            // `ClientGre` accumulates its full JSON body until brace-balance
-            // flush (default feature) or the next header arrives.
-            //
             // `TruncationMarker` is followed by 3 sub-header lines
             // (`::: GameStateMessage`, `:: GameObject Count = N`,
             // `:: Annotation Count = M`) that must accumulate into the entry
             // body so the thin truncation parser can extract the counts.
             // Its body never opens a `{`, so brace-balance flush doesn't
             // fire — accumulation terminates when the next header arrives.
-            EntryHeader::ClientGre | EntryHeader::TruncationMarker => HeaderClass::MultiLine,
+            EntryHeader::TruncationMarker => HeaderClass::MultiLine,
             // ConnectionManager and Matchmaking are corpus-confirmed
             // single-line. Metadata (`DETAILED LOGS: …`) is handled directly
             // in `push_line` and never reaches this function — but it must
@@ -595,21 +584,11 @@ mod tests {
         }
 
         #[test]
-        fn test_as_str_client_gre() {
-            assert_eq!(EntryHeader::ClientGre.as_str(), "[Client GRE]");
-        }
-
-        #[test]
         fn test_display_unity() {
             assert_eq!(
                 EntryHeader::UnityCrossThreadLogger.to_string(),
                 "[UnityCrossThreadLogger]"
             );
-        }
-
-        #[test]
-        fn test_display_client_gre() {
-            assert_eq!(EntryHeader::ClientGre.to_string(), "[Client GRE]");
         }
 
         #[test]
@@ -639,7 +618,7 @@ mod tests {
             let mut buf = LineBuffer::new();
             buf.push_line("[UnityCrossThreadLogger]1/1/2025 Event1");
             assert_eq!(
-                buf.push_line("[Client GRE] 1/1/2025 Event2"),
+                buf.push_line("[UnityCrossThreadLogger]1/1/2025 Event2"),
                 vec![expected(
                     EntryHeader::UnityCrossThreadLogger,
                     "[UnityCrossThreadLogger]1/1/2025 Event1",
@@ -668,54 +647,12 @@ mod tests {
         }
 
         #[test]
-        fn test_push_line_client_gre_header_detected() {
-            let mut buf = LineBuffer::new();
-            buf.push_line("[Client GRE] GreMessage");
-            assert_eq!(
-                buf.flush(),
-                Some(expected(EntryHeader::ClientGre, "[Client GRE] GreMessage")),
-            );
-        }
-
-        /// Regression: `[Client GRE]` continues to accumulate continuation
-        /// lines after Phase 1 (multi-line classification preserved). With
-        /// the default `brace_depth_flush` feature on, the entry is emitted
-        /// by the closing `}` line via `push_line` rather than waiting for
-        /// `flush()` — both code paths assemble the same body.
-        #[test]
-        fn test_push_line_client_gre_header_accumulates() {
-            let expected_body = "[Client GRE] GreToClientEvent\n{\n  \"key\": \"value\"\n}";
-            let mut buf = LineBuffer::new();
-            buf.push_line("[Client GRE] GreToClientEvent");
-            buf.push_line("{");
-            buf.push_line(r#"  "key": "value""#);
-            let closing = buf.push_line("}");
-            #[cfg(feature = "brace_depth_flush")]
-            {
-                assert_eq!(
-                    closing,
-                    vec![expected(EntryHeader::ClientGre, expected_body)],
-                    "closing brace must flush the entry under brace_depth_flush",
-                );
-                assert!(buf.flush().is_none());
-            }
-            #[cfg(not(feature = "brace_depth_flush"))]
-            {
-                assert!(closing.is_empty());
-                assert_eq!(
-                    buf.flush(),
-                    Some(expected(EntryHeader::ClientGre, expected_body)),
-                );
-            }
-        }
-
-        #[test]
         fn test_push_line_alternating_multi_line_headers() {
             let mut buf = LineBuffer::new();
             buf.push_line("[UnityCrossThreadLogger]1/1/2025 Event1");
 
             assert_eq!(
-                buf.push_line("[Client GRE] Event2"),
+                buf.push_line("[UnityCrossThreadLogger]1/1/2025 Event2"),
                 vec![expected(
                     EntryHeader::UnityCrossThreadLogger,
                     "[UnityCrossThreadLogger]1/1/2025 Event1",
@@ -724,7 +661,10 @@ mod tests {
 
             assert_eq!(
                 buf.push_line("[UnityCrossThreadLogger]1/1/2025 Event3"),
-                vec![expected(EntryHeader::ClientGre, "[Client GRE] Event2")],
+                vec![expected(
+                    EntryHeader::UnityCrossThreadLogger,
+                    "[UnityCrossThreadLogger]1/1/2025 Event2",
+                )],
             );
 
             assert_eq!(
@@ -985,7 +925,7 @@ mod tests {
         #[test]
         fn test_flush_multi_line_entry() {
             let expected_body = [
-                "[Client GRE] GreToClientEvent",
+                "[UnityCrossThreadLogger]1/1/2025 GreToClientEvent",
                 "{",
                 r#"  "gameObjects": ["obj1", "obj2"],"#,
                 r#"  "actions": []"#,
@@ -994,7 +934,7 @@ mod tests {
             .join("\n");
 
             let mut buf = LineBuffer::new();
-            buf.push_line("[Client GRE] GreToClientEvent");
+            buf.push_line("[UnityCrossThreadLogger]1/1/2025 GreToClientEvent");
             buf.push_line("{");
             buf.push_line(r#"  "gameObjects": ["obj1", "obj2"],"#);
             buf.push_line(r#"  "actions": []"#);
@@ -1006,7 +946,10 @@ mod tests {
                 // is left with nothing to return.
                 assert_eq!(
                     closing,
-                    vec![expected(EntryHeader::ClientGre, &expected_body)],
+                    vec![expected(
+                        EntryHeader::UnityCrossThreadLogger,
+                        &expected_body
+                    )],
                 );
                 assert!(buf.flush().is_none());
             }
@@ -1015,7 +958,10 @@ mod tests {
                 assert!(closing.is_empty());
                 assert_eq!(
                     buf.flush(),
-                    Some(expected(EntryHeader::ClientGre, &expected_body)),
+                    Some(expected(
+                        EntryHeader::UnityCrossThreadLogger,
+                        &expected_body
+                    )),
                 );
             }
         }
@@ -1060,10 +1006,13 @@ mod tests {
             let mut buf = LineBuffer::new();
             buf.push_line("[UnityCrossThreadLogger]1/1/2025 Old");
             buf.reset();
-            buf.push_line("[Client GRE] New");
+            buf.push_line("[UnityCrossThreadLogger]1/1/2025 New");
             assert_eq!(
                 buf.flush(),
-                Some(expected(EntryHeader::ClientGre, "[Client GRE] New")),
+                Some(expected(
+                    EntryHeader::UnityCrossThreadLogger,
+                    "[UnityCrossThreadLogger]1/1/2025 New",
+                )),
             );
         }
     }
@@ -1226,32 +1175,38 @@ mod tests {
                 assert!(final_brace[0].body.contains("greToClientMessages"));
                 assert!(final_brace[0].body.contains("GameStateMessage"));
 
-                // `[Client GRE] Next event` now begins a new accumulation
-                // — nothing else to flush.
-                assert!(buf.push_line("[Client GRE] Next event").is_empty());
+                // A second UCTL multi-line entry begins accumulating.
+                // No `{` in the body, so it falls through to the next-header flush.
+                assert!(buf
+                    .push_line("[UnityCrossThreadLogger]1/15/2025 Next event")
+                    .is_empty());
 
-                // The Client-GRE body has no `{`, so it falls through to
-                // the legacy "flush on next header" path.
                 assert_eq!(
                     buf.push_line("[UnityCrossThreadLogger]1/15/2025 After"),
-                    vec![expected(EntryHeader::ClientGre, "[Client GRE] Next event")],
+                    vec![expected(
+                        EntryHeader::UnityCrossThreadLogger,
+                        "[UnityCrossThreadLogger]1/15/2025 Next event",
+                    )],
                 );
             }
             #[cfg(not(feature = "brace_depth_flush"))]
             {
                 assert!(final_brace.is_empty());
 
-                // [Client GRE] (multi-line) flushes the UCTL entry.
-                let unity_entries = buf.push_line("[Client GRE] Next event");
+                // Second UCTL (multi-line) flushes the first UCTL entry.
+                let unity_entries = buf.push_line("[UnityCrossThreadLogger]1/15/2025 Next event");
                 assert_eq!(unity_entries.len(), 1);
                 assert_eq!(unity_entries[0].header, EntryHeader::UnityCrossThreadLogger);
                 assert!(unity_entries[0].body.contains("greToClientMessages"));
                 assert!(unity_entries[0].body.contains("GameStateMessage"));
 
-                // The next header flushes the Client GRE entry.
+                // The next header flushes the second entry.
                 assert_eq!(
                     buf.push_line("[UnityCrossThreadLogger]1/15/2025 After"),
-                    vec![expected(EntryHeader::ClientGre, "[Client GRE] Next event")],
+                    vec![expected(
+                        EntryHeader::UnityCrossThreadLogger,
+                        "[UnityCrossThreadLogger]1/15/2025 Next event",
+                    )],
                 );
             }
         }
@@ -1751,15 +1706,15 @@ mod tests {
         #[test]
         fn test_multi_line_pretty_printed_json_flushes_on_closing_brace() {
             let mut buf = LineBuffer::new();
-            buf.push_line("[Client GRE] GreToClientEvent");
+            buf.push_line("[UnityCrossThreadLogger]1/1/2025 GreToClientEvent");
             buf.push_line("{");
             buf.push_line(r#"  "key": "val""#);
             let result = buf.push_line("}");
             assert_eq!(result.len(), 1);
-            assert_eq!(result[0].header, EntryHeader::ClientGre);
+            assert_eq!(result[0].header, EntryHeader::UnityCrossThreadLogger);
             assert_eq!(
                 result[0].body,
-                "[Client GRE] GreToClientEvent\n{\n  \"key\": \"val\"\n}",
+                "[UnityCrossThreadLogger]1/1/2025 GreToClientEvent\n{\n  \"key\": \"val\"\n}",
             );
             assert!(buf.is_empty());
         }
@@ -1789,16 +1744,16 @@ mod tests {
         #[test]
         fn test_non_json_body_falls_through_to_next_header() {
             let mut buf = LineBuffer::new();
-            buf.push_line("[Client GRE] GreToClientEvent");
+            buf.push_line("[UnityCrossThreadLogger]1/1/2025 GreToClientEvent");
             assert!(buf.push_line("(payload elided)").is_empty());
             assert!(buf.push_line(":: 12345 entries").is_empty());
             assert!(buf.push_line(":: payload trimmed").is_empty());
 
-            // Next header flushes the accumulating Client-GRE entry — the
-            // entry was never brace-flushed because no `{` appeared.
+            // Next header flushes the accumulating entry — never brace-flushed
+            // because no `{` appeared.
             let entries = buf.push_line("[UnityCrossThreadLogger]1/1/2025 After");
             assert_eq!(entries.len(), 1);
-            assert_eq!(entries[0].header, EntryHeader::ClientGre);
+            assert_eq!(entries[0].header, EntryHeader::UnityCrossThreadLogger);
             assert!(entries[0].body.contains("(payload elided)"));
             assert!(entries[0].body.contains(":: 12345 entries"));
         }
@@ -1827,12 +1782,15 @@ mod tests {
             // `ever_opened=true` would falsely flush this entry's first
             // continuation line. With reset, it accumulates normally and
             // the next header flushes it.
-            buf.push_line("[Client GRE] PlainBodyEvent");
+            buf.push_line("[UnityCrossThreadLogger]1/1/2025 PlainBodyEvent");
             assert!(buf.push_line("just text").is_empty());
             let entries = buf.push_line("[UnityCrossThreadLogger]1/1/2025 Third");
             assert_eq!(entries.len(), 1);
-            assert_eq!(entries[0].header, EntryHeader::ClientGre);
-            assert_eq!(entries[0].body, "[Client GRE] PlainBodyEvent\njust text");
+            assert_eq!(entries[0].header, EntryHeader::UnityCrossThreadLogger);
+            assert_eq!(
+                entries[0].body,
+                "[UnityCrossThreadLogger]1/1/2025 PlainBodyEvent\njust text",
+            );
         }
 
         /// After a brace-flush, subsequent headerless lines must be treated

--- a/src/log/tailer.rs
+++ b/src/log/tailer.rs
@@ -866,7 +866,7 @@ mod tests {
             assert!(entries1.is_empty());
 
             // Second write — new header flushes previous entry.
-            writeln!(f, "[Client GRE] Event2")?;
+            writeln!(f, "[UnityCrossThreadLogger]1/1/2025 Event2")?;
             f.flush()?;
             let entries2 = tailer.poll().await?;
             assert_eq!(entries2.len(), 1);
@@ -997,13 +997,12 @@ mod tests {
             // Write a complete (multi-line) header line followed by a
             // partial line that is itself a header (no trailing newline).
             writeln!(f, "[UnityCrossThreadLogger]1/1/2025 First")?;
-            write!(f, "[Client GRE] Second")?;
+            write!(f, "[UnityCrossThreadLogger]1/1/2025 Second")?;
             f.flush()?;
             tailer.poll().await?;
 
             // flush() should return both: the "First" entry flushed by the
-            // "[Client GRE]" header, and the "[Client GRE] Second" entry
-            // drained from the line buffer.
+            // second header, and the "Second" entry drained from the line buffer.
             let entries = tailer.flush();
             assert_eq!(
                 entries.len(),

--- a/src/parsers/connection_close.rs
+++ b/src/parsers/connection_close.rs
@@ -599,8 +599,8 @@ mod tests {
         fn test_non_unity_cross_thread_logger_header_returns_none() {
             // Correct marker text but wrong header — must not parse.
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]Client.TcpConnection.Close {\"status\":7,\"reason\":\"Closed by remote end\"}"
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]Client.TcpConnection.Close {\"status\":7,\"reason\":\"Closed by remote end\"}"
                     .to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());

--- a/src/parsers/connection_error.rs
+++ b/src/parsers/connection_error.rs
@@ -599,11 +599,11 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_client_gre_header_returns_none() {
+        fn test_matchmaking_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
+                header: EntryHeader::Matchmaking,
                 body: format!(
-                    "[Client GRE]{PROCESS_READ_EXCEPTION_MARKER} {{\"function\":\"ReadAsync\"}}"
+                    "Matchmaking:{PROCESS_READ_EXCEPTION_MARKER} {{\"function\":\"ReadAsync\"}}"
                 ),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
@@ -820,11 +820,11 @@ mod tests {
         }
 
         #[test]
-        fn test_client_gre_header_with_reconnect_body_returns_none() {
+        fn test_unity_header_with_reconnect_body_returns_none() {
             // Confirms dispatch is header-gated: a ConnectionManager-shaped
-            // body under the wrong header (ClientGre) must return None.
+            // body under the wrong header (UnityCrossThreadLogger) must return None.
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
+                header: EntryHeader::UnityCrossThreadLogger,
                 body: "[ConnectionManager] Reconnect result : Connected".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());

--- a/src/parsers/connection_state.rs
+++ b/src/parsers/connection_state.rs
@@ -237,10 +237,10 @@ mod tests {
         }
 
         #[test]
-        fn test_client_gre_header_returns_none() {
+        fn test_connection_manager_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]STATE CHANGED {\"old\":\"Playing\",\"new\":\"Disconnected\"}"
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]STATE CHANGED {\"old\":\"Playing\",\"new\":\"Disconnected\"}"
                     .to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());

--- a/src/parsers/draft/bot.rs
+++ b/src/parsers/draft/bot.rs
@@ -631,10 +631,10 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_header_returns_none() {
+        fn test_try_parse_connection_manager_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]some GRE message".to_owned(),
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]some connection message".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }

--- a/src/parsers/draft/complete.rs
+++ b/src/parsers/draft/complete.rs
@@ -463,10 +463,10 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_header_returns_none() {
+        fn test_try_parse_connection_manager_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]some GRE message".to_owned(),
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]some connection message".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }

--- a/src/parsers/draft/human.rs
+++ b/src/parsers/draft/human.rs
@@ -784,10 +784,10 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_header_returns_none() {
+        fn test_try_parse_connection_manager_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]some GRE message".to_owned(),
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]some connection message".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }

--- a/src/parsers/event_lifecycle.rs
+++ b/src/parsers/event_lifecycle.rs
@@ -497,10 +497,10 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_header_returns_none() {
+        fn test_try_parse_connection_manager_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]some GRE message".to_owned(),
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]some connection message".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -508,9 +508,11 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_header_is_accepted() {
+        fn test_try_parse_gre_content_parsed_regardless_of_header() {
+            // The GRE parser gates on body content (greToClientEvent marker),
+            // not on the header type. Any entry carrying the marker is parsed.
             let body = format!(
-                "[Client GRE]greToClientEvent\n{}",
+                "[UnityCrossThreadLogger]greToClientEvent\n{}",
                 serde_json::json!({
                     "greToClientEvent": {
                         "greToClientMessages": [
@@ -526,12 +528,9 @@ mod tests {
                 })
             );
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
+                header: EntryHeader::UnityCrossThreadLogger,
                 body: body.clone(),
             };
-            // Note: This returns events because the parser only checks the body
-            // content, not the header type. The GRE marker is present in the
-            // body. This is valid -- ConnectResp can appear under either header.
             let results = try_parse(&entry, Some(test_timestamp()));
             assert_eq!(results.len(), 1);
         }

--- a/src/parsers/inventory.rs
+++ b/src/parsers/inventory.rs
@@ -260,10 +260,10 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_header_returns_none() {
+        fn test_try_parse_connection_manager_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]some GRE message".to_owned(),
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]some connection message".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }

--- a/src/parsers/match_state.rs
+++ b/src/parsers/match_state.rs
@@ -710,10 +710,10 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_entry_returns_none() {
+        fn test_try_parse_connection_manager_entry_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]matchGameRoomStateChangedEvent".to_owned(),
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]matchGameRoomStateChangedEvent".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }

--- a/src/parsers/metadata.rs
+++ b/src/parsers/metadata.rs
@@ -157,9 +157,9 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_header_returns_none() {
+        fn test_try_parse_connection_manager_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
+                header: EntryHeader::ConnectionManager,
                 body: "DETAILED LOGS: ENABLED".to_owned(),
             };
             assert!(try_parse(&entry, None).is_none());

--- a/src/parsers/rank.rs
+++ b/src/parsers/rank.rs
@@ -212,10 +212,10 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_header_returns_none() {
+        fn test_try_parse_connection_manager_header_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]some GRE message".to_owned(),
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]some connection message".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }

--- a/src/parsers/session.rs
+++ b/src/parsers/session.rs
@@ -56,8 +56,8 @@ pub fn try_parse(
     None
 }
 
-/// Strips the `[UnityCrossThreadLogger]` or `[Client GRE]` bracket prefix
-/// from the first line of the body, returning the remaining content.
+/// Strips the `[UnityCrossThreadLogger]` bracket prefix from the first line
+/// of the body, returning the remaining content.
 ///
 /// If the body does not start with a recognized bracket prefix, returns
 /// the full body unchanged.
@@ -332,10 +332,10 @@ mod tests {
         }
 
         #[test]
-        fn test_try_parse_client_gre_entry_returns_none() {
+        fn test_try_parse_connection_manager_entry_returns_none() {
             let entry = LogEntry {
-                header: EntryHeader::ClientGre,
-                body: "[Client GRE]some GRE message".to_owned(),
+                header: EntryHeader::ConnectionManager,
+                body: "[ConnectionManager]some connection message".to_owned(),
             };
             assert!(try_parse(&entry, Some(test_timestamp())).is_none());
         }
@@ -385,9 +385,9 @@ mod tests {
         }
 
         #[test]
-        fn test_strip_header_prefix_client_gre() {
-            let result = strip_header_prefix("[Client GRE]gre content");
-            assert_eq!(result, "gre content");
+        fn test_strip_header_prefix_connection_manager() {
+            let result = strip_header_prefix("[ConnectionManager]connection content");
+            assert_eq!(result, "connection content");
         }
 
         #[test]

--- a/src/parsers/session.rs
+++ b/src/parsers/session.rs
@@ -24,7 +24,7 @@ const FRONT_DOOR_CLOSE_MARKER: &str = "FrontDoorConnection.Close";
 /// Attempts to parse a [`LogEntry`] as a session event.
 ///
 /// Returns `Some(GameEvent::Session(_))` if the entry matches one of the
-/// three recognized session signatures, or `None` if the entry is not a
+/// two recognized session signatures, or `None` if the entry is not a
 /// session event.
 ///
 /// The `timestamp` is `None` when the log entry header did not contain a

--- a/src/router.rs
+++ b/src/router.rs
@@ -186,7 +186,6 @@ impl Default for Router {
 /// The expected format is:
 /// ```text
 /// [UnityCrossThreadLogger]2/25/2026 12:00:00 PM some content
-/// [Client GRE]2/25/2026 12:00:00 PM GreToClientEvent
 /// [UnityCrossThreadLogger]3/13/2026 11:34:51 PM: Match to ...
 /// ```
 ///
@@ -311,14 +310,6 @@ mod tests {
         }
     }
 
-    /// Helper: build a `LogEntry` with `ClientGre` header.
-    fn gre_entry(body: &str) -> LogEntry {
-        LogEntry {
-            header: EntryHeader::ClientGre,
-            body: body.to_owned(),
-        }
-    }
-
     // -- extract_timestamp ---------------------------------------------------
 
     mod extract_timestamp_tests {
@@ -371,13 +362,6 @@ mod tests {
                     "2026-02-25 14:30:00"
                 );
             }
-        }
-
-        #[test]
-        fn test_extract_timestamp_client_gre_header() {
-            let body = "[Client GRE]2/25/2026 12:00:00 PM GreToClientEvent";
-            let ts = extract_timestamp(body);
-            assert!(ts.is_some());
         }
 
         #[test]
@@ -824,35 +808,6 @@ mod tests {
             let router = Router::default();
             assert_eq!(router.stats().routed_count(), 0);
             assert_eq!(router.stats().unknown_count(), 0);
-        }
-    }
-
-    // -- Router: Client GRE header entries -----------------------------------
-
-    mod client_gre_entries {
-        use super::*;
-
-        #[test]
-        fn test_route_client_gre_entry() {
-            let router = Router::new();
-            let payload = serde_json::json!({
-                "greToClientEvent": {
-                    "greToClientMessages": [{
-                        "type": "GREMessageType_GameStateMessage",
-                        "gameStateMessage": {
-                            "gameInfo": { "stage": "GameStage_Play" },
-                            "gameObjects": [],
-                            "zones": []
-                        }
-                    }]
-                }
-            });
-            let body = format!("[Client GRE]2/25/2026 12:00:00 PM\n{payload}");
-            let entry = gre_entry(&body);
-
-            let results = router.route(&entry);
-            assert_eq!(results.len(), 1);
-            assert!(matches!(&results[0], GameEvent::GameState(_)));
         }
     }
 

--- a/tests/corpus_flush_timing.rs
+++ b/tests/corpus_flush_timing.rs
@@ -161,7 +161,6 @@ fn test_replay_produces_expected_entry_count() {
             line.starts_with("[UnityCrossThreadLogger]")
                 || line.starts_with("[ConnectionManager]")
                 || line.starts_with("Matchmaking: ")
-                || line.starts_with("[Client GRE]")
         })
         .collect();
 


### PR DESCRIPTION
## Summary

- Removes `EntryHeader::ClientGre` from the enum — `[Client GRE]` never appears in real MTGA logs (0 hits across 44 sessions / 606,267 corpus lines)
- Drops the `Client GRE` alternation from the bracket-header regex and all five associated match arms (`as_str`, `detect_header`, `classify_header`, `Display`)
- Updates doc comments in `entry.rs`, `router.rs`, `session.rs`, and `events.rs` that referenced `[Client GRE]` or `LogBusinessEvents` (stale from #205)
- Replaces every test fixture using `EntryHeader::ClientGre` with `ConnectionManager` or `UnityCrossThreadLogger`; removes the two tests that specifically validated `[Client GRE]` detection (dead-code behaviour)
- Updates `corpus_flush_timing.rs` header filter (`[Client GRE]` was a no-op branch — zero corpus lines match)

Same pattern as #149, #156, and #205 — speculative scaffolding added before the corpus was available.

## Test plan

- [x] `grep -rn "ClientGre\|Client GRE" src/ tests/` returns no results ✓
- [x] All 1,113 existing tests pass (`cargo test --all-features`) ✓
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`) ✓
- [x] Formatting clean (`cargo fmt --all -- --check`) ✓

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)