### PR TITLE
Fix #212: Linux (Steam/Proton + Lutris) Player.log discovery

### DIFF
--- a/.claude/timing-logs/seq-issues-2026-05-28T204606Z-15fe10cb.md
+++ b/.claude/timing-logs/seq-issues-2026-05-28T204606Z-15fe10cb.md
@@ -1,0 +1,85 @@
+# Sequential-issues run 2026-05-28 20:46 UTC
+
+**Run id:** 15fe10cb
+**Started at:** 2026-05-28T20:46:06Z
+**CARGO_TARGET_DIR (orchestrator, post-resolution):** UNSET
+
+<!-- mns:timing-summary-start -->
+
+**Total wall-clock:** 17m 40s
+
+## Key phases
+
+| Phase | Total |
+|---|---|
+| subagent-spawn | 8m 45s |
+| research | 17s |
+| implement | 2m 54s |
+| precommit | 1m 7s |
+| review | 1m 32s |
+| fast-checks | 0s |
+| ci-watcher | 7m 21s |
+| ci-queue | 8s |
+
+## Per-issue totals
+
+| Issue | PR | Wall-clock | Pre-commit reruns | Review iterations | CI runs |
+|---|---|---|---|---|---|
+| 212 | #213 | 16m 14s | 1 | 1 | 2 |
+
+## Phase aggregates
+
+| Phase | Total |
+|---|---|
+| ci-watcher | 7m 21s |
+| ci:fix | 51s |
+| ci:wait | 5m 19s |
+| fast-checks | 0s |
+| git-setup | 6s |
+| implement | 2m 54s |
+| notarize-label | 0s |
+| parse-args | 9s |
+| pr-create | 27s |
+| precommit:full | 1m 7s |
+| research | 17s |
+| review:run | 1m 32s |
+| subagent-spawn | 8m 45s |
+| validate-base | 0s |
+
+<!-- mns:timing-summary-end -->
+
+## Events
+| Time (UTC) | Issue | Phase | Step | Event | Note |
+|---|---|---|---|---|---|
+| 20:46:06 | - | parse-args | - | start |  |
+| 20:46:15 | - | parse-args | - | end |  |
+| 20:46:15 | - | validate-base | - | start |  |
+| 20:46:15 | - | validate-base | - | end | base=main (skipped) |
+| 20:47:23 | - | env | cargo-target-dir | verify | UNSET |
+| 20:47:32 | 212 | subagent-spawn | - | start |  |
+| 20:48:29 | 212 | research | - | start |  |
+| 20:48:46 | 212 | research | - | end | Research complete: read issue, discovery.rs, steam.rs desktop source, Cargo.toml, CHANGELOG |
+| 20:48:50 | 212 | env | cargo-target-dir | verify | UNSET |
+| 20:48:54 | 212 | git-setup | - | start |  |
+| 20:49:00 | 212 | git-setup | - | end |  |
+| 20:49:03 | 212 | implement | - | start |  |
+| 20:51:57 | 212 | implement | - | end | Implementation complete: steam.rs, Linux arm in discovery.rs, tests, CHANGELOG, version bump |
+| 20:52:00 | 212 | precommit:full | - | start |  |
+| 20:53:07 | 212 | precommit:full | - | end | fmt+clippy clean; test_discover_log_file_returns_error_in_ci pre-existing local fail (MTGA installed) |
+| 20:53:45 | 212 | pr-create | - | start |  |
+| 20:54:12 | 212 | pr-create | - | end | PR #213 |
+| 20:54:16 | 212 | review:run | 1 | start |  |
+| 20:55:48 | 212 | review:run | 1 | end | No issues found |
+| 20:56:17 | 212 | subagent-spawn | - | end | gate1_approved PR #213 |
+| 20:56:17 | 212 | fast-checks | 1 | start |  |
+| 20:56:17 | 212 | fast-checks | 1 | end | skipped (N=1) |
+| 20:56:25 | - | notarize-label | - | start |  |
+| 20:56:25 | - | notarize-label | - | end | skipped (repo=manasight-parser) |
+| 20:56:25 | 212 | ci-watcher | - | start |  |
+| 20:57:06 | 212 | ci:wait | 1 | start |  |
+| 20:57:27 | 212 | ci:wait | 1 | end | gh-run-id 26601658559 queue=5s FAILURE: clippy doc_markdown at discovery.rs:526 - LocalLow missing backticks |
+| 20:57:30 | 212 | ci:fix | 1 | start |  |
+| 20:58:21 | 212 | ci:fix | 1 | end | Fixed: discovery.rs:526 - LocalLow missing backticks in doc comment (clippy::doc_markdown) |
+| 20:58:24 | 212 | ci:wait | 2 | start |  |
+| 21:03:22 | 212 | ci:wait | 2 | end | gh-run-id 26601873277 queue=3s ALL_GREEN |
+| 21:03:46 | 212 | ci-watcher | - | end | approved |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Linux (Steam/Proton + Lutris) `Player.log` auto-discovery in `discover_log_file()`.
+  Parses `~/.local/share/Steam/steamapps/libraryfolders.vdf` to find the Steam library
+  containing MTGA (app id 2141910) across any configured disk, with a Lutris prefix
+  fallback. On Linux, `UnsupportedPlatform` is no longer returned; instead, a
+  `LogFileMissing` error (matching the Windows/macOS absent-file contract) is returned
+  when no candidate location contains a `Player.log` (#212, manasight/manasight-docs#772).
+
 ### Fixed
 
 - GameOver `GameStateMessage`s carrying annotations (e.g. the lethal combat damage that ends the match) no longer drop them silently. When `gameInfo.stage == GameStage_GameOver` and the GSM has a non-empty `annotations` or `persistentAnnotations` array, the parser now emits a `GameEvent::GameState` carrying both arrays immediately before the existing `GameEvent::GameResult`. Per-producer ordering on the broadcast channel guarantees annotation-walker consumers see the killing-blow data before the result payload. GameOver GSMs with empty annotation arrays continue to emit only the `GameResult` event; the `MatchState_MatchComplete` suppression branch is unchanged (#196).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   containing MTGA (app id 2141910) across any configured disk, with a Lutris prefix
   fallback. On Linux, `UnsupportedPlatform` is no longer returned; instead, a
   `LogFileMissing` error (matching the Windows/macOS absent-file contract) is returned
-  when no candidate location contains a `Player.log` (#212, manasight/manasight-docs#772).
+  when no candidate location contains a `Player.log` (#212).
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manasight-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/src/log/discovery.rs
+++ b/src/log/discovery.rs
@@ -1,7 +1,8 @@
 //! Platform-specific log file path resolution.
 //!
 //! Resolves the default location of MTG Arena's `Player.log` on each
-//! supported platform (Windows via `known-folders`, macOS via `~/Library/Logs/`).
+//! supported platform (Windows via `known-folders`, macOS via `~/Library/Logs/`,
+//! Linux via Steam/Proton `libraryfolders.vdf` or Lutris fallback).
 //!
 //! # Usage
 //!
@@ -76,7 +77,8 @@ pub enum DiscoveryError {
 
     /// The current operating system is not supported.
     ///
-    /// Only Windows and macOS are supported targets.
+    /// Only Windows, macOS, and Linux (Steam/Proton via `libraryfolders.vdf`,
+    /// Lutris fallback) are supported targets.
     #[error("unsupported platform for log file discovery")]
     UnsupportedPlatform,
 }
@@ -118,8 +120,103 @@ fn resolve_base_dir() -> Result<PathBuf, DiscoveryError> {
         .ok_or(DiscoveryError::BaseDirNotFound)
 }
 
-/// Returns [`DiscoveryError::UnsupportedPlatform`] on non-Windows/macOS targets.
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+/// Resolves the platform base directory for MTGA logs on Linux.
+///
+/// Tries candidates in order (Steam/Proton first, then Lutris) and returns
+/// the `.../LocalLow` base dir for the first candidate whose `Player.log`
+/// exists.  The Linux arm is existence-aware because the base directory
+/// must be discovered dynamically (Steam library can be on any disk).
+///
+/// Returns [`DiscoveryError::LogFileMissing`] (not [`DiscoveryError::UnsupportedPlatform`])
+/// when no candidate contains a `Player.log`, matching the absent-file
+/// contract of the Windows/macOS arms.
+#[cfg(target_os = "linux")]
+fn resolve_base_dir() -> Result<PathBuf, DiscoveryError> {
+    use crate::log::steam::{steam_library_for_appid, MTGA_APP_ID};
+
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or(DiscoveryError::BaseDirNotFound)?;
+
+    let steam_lib = steam_library_for_appid(MTGA_APP_ID);
+    let candidates = linux_candidate_base_dirs(&home, steam_lib.as_deref());
+
+    let mtga_tail = Path::new("Wizards Of The Coast")
+        .join("MTGA")
+        .join("Player.log");
+
+    for candidate in &candidates {
+        if candidate.join(&mtga_tail).exists() {
+            ::log::info!("Linux: discovered MTGA base dir: {}", candidate.display());
+            return Ok(candidate.clone());
+        }
+    }
+
+    // Nothing found: report the Lutris path (last candidate) as the missing
+    // path so callers can surface a useful "file not found" message.
+    // The Lutris candidate is always present in the list (linux_candidate_base_dirs
+    // always appends it), so last() is always Some; fall back to building the
+    // Lutris path directly if the vector were somehow empty.
+    let lutris_locallow = home
+        .join("Games")
+        .join("magic-the-gathering-arena")
+        .join("drive_c")
+        .join("users")
+        .join("steamuser")
+        .join("AppData")
+        .join("LocalLow");
+    let missing_path = candidates.into_iter().last().map_or_else(
+        || lutris_locallow.join(&mtga_tail),
+        |base| base.join(&mtga_tail),
+    );
+
+    ::log::warn!(
+        "Linux: no MTGA Player.log found; last checked: {}",
+        missing_path.display()
+    );
+    Err(DiscoveryError::LogFileMissing { path: missing_path })
+}
+
+/// Returns the ordered `.../LocalLow` candidate base directories for Linux
+/// MTGA discovery (Steam/Proton first, Lutris second).
+///
+/// This pure helper takes `home` and an optional `steam_lib` so it can be
+/// unit-tested with temp directories without mutating `$HOME`.
+#[cfg(target_os = "linux")]
+pub(crate) fn linux_candidate_base_dirs(home: &Path, steam_lib: Option<&Path>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    // Steam/Proton (primary)
+    if let Some(library) = steam_lib {
+        let locallow = library
+            .join("steamapps")
+            .join("compatdata")
+            .join("2141910")
+            .join("pfx")
+            .join("drive_c")
+            .join("users")
+            .join("steamuser")
+            .join("AppData")
+            .join("LocalLow");
+        candidates.push(locallow);
+    }
+
+    // Lutris (fallback, UNVERIFIED — manasight/manasight-docs#772)
+    let lutris_locallow = home
+        .join("Games")
+        .join("magic-the-gathering-arena")
+        .join("drive_c")
+        .join("users")
+        .join("steamuser")
+        .join("AppData")
+        .join("LocalLow");
+    candidates.push(lutris_locallow);
+
+    candidates
+}
+
+/// Returns [`DiscoveryError::UnsupportedPlatform`] on non-Windows/macOS/Linux targets.
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 fn resolve_base_dir() -> Result<PathBuf, DiscoveryError> {
     Err(DiscoveryError::UnsupportedPlatform)
 }
@@ -168,10 +265,16 @@ fn check_existence(paths: LogPaths) -> Result<LogPaths, DiscoveryError> {
 /// Useful for displaying the expected path in configuration UI or logs.
 /// Use [`discover_log_file`] to also verify the file exists.
 ///
+/// Note: on Linux the base directory is auto-discovered (Steam library can
+/// be on any configured disk), so the Linux arm performs existence checks
+/// internally as part of resolution.  A successful return on Linux means
+/// the file was found; a [`DiscoveryError::LogFileMissing`] return means
+/// no candidate location contained a `Player.log`.
+///
 /// # Errors
 ///
 /// - [`DiscoveryError::UnsupportedPlatform`] on platforms other than
-///   Windows and macOS.
+///   Windows, macOS, and Linux.
 /// - [`DiscoveryError::BaseDirNotFound`] if the platform base directory
 ///   cannot be resolved.
 pub fn resolve_log_paths() -> Result<LogPaths, DiscoveryError> {
@@ -188,7 +291,8 @@ pub fn resolve_log_paths() -> Result<LogPaths, DiscoveryError> {
 ///
 /// # Errors
 ///
-/// - [`DiscoveryError::UnsupportedPlatform`] on unsupported platforms.
+/// - [`DiscoveryError::UnsupportedPlatform`] on platforms other than
+///   Windows, macOS, and Linux.
 /// - [`DiscoveryError::BaseDirNotFound`] if the platform base directory
 ///   cannot be resolved.
 /// - [`DiscoveryError::LogFileMissing`] if the resolved path does not
@@ -395,18 +499,166 @@ mod tests {
 
     // -- Platform-specific resolution --
 
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     #[test]
     fn test_resolve_log_paths_unsupported_platform() {
         let result = resolve_log_paths();
         assert!(matches!(result, Err(DiscoveryError::UnsupportedPlatform)));
     }
 
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     #[test]
     fn test_discover_log_file_unsupported_platform() {
         let result = discover_log_file();
         assert!(matches!(result, Err(DiscoveryError::UnsupportedPlatform)));
+    }
+
+    // -- Linux candidate base dir discovery (pure helper, tempdir-safe) --
+
+    #[cfg(target_os = "linux")]
+    mod linux_discovery {
+        use super::*;
+        use crate::log::discovery::linux_candidate_base_dirs;
+        use std::fs;
+
+        type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+        /// Build the full Player.log path under a LocalLow base dir.
+        fn player_log_path(locallow: &Path) -> PathBuf {
+            locallow
+                .join("Wizards Of The Coast")
+                .join("MTGA")
+                .join("Player.log")
+        }
+
+        #[test]
+        fn test_linux_candidate_base_dirs_steam_first_lutris_second() {
+            let home = PathBuf::from("/home/testuser");
+            let steam_lib = PathBuf::from("/mnt/games/SteamLibrary");
+            let candidates = linux_candidate_base_dirs(&home, Some(&steam_lib));
+
+            assert_eq!(candidates.len(), 2);
+            // Steam candidate is first
+            assert!(candidates[0]
+                .to_string_lossy()
+                .contains("steamapps/compatdata"));
+            assert!(candidates[0].to_string_lossy().contains("2141910"));
+            // Lutris candidate is second
+            assert!(candidates[1]
+                .to_string_lossy()
+                .contains("Games/magic-the-gathering-arena"));
+        }
+
+        #[test]
+        fn test_linux_candidate_base_dirs_no_steam_only_lutris() {
+            let home = PathBuf::from("/home/testuser");
+            let candidates = linux_candidate_base_dirs(&home, None);
+
+            assert_eq!(candidates.len(), 1);
+            assert!(candidates[0]
+                .to_string_lossy()
+                .contains("Games/magic-the-gathering-arena"));
+        }
+
+        #[test]
+        fn test_linux_resolve_base_dir_steam_found() -> TestResult {
+            let tmp = tempfile::tempdir()?;
+            let steam_lib = tmp.path().join("SteamLibrary");
+            let locallow = steam_lib
+                .join("steamapps")
+                .join("compatdata")
+                .join("2141910")
+                .join("pfx")
+                .join("drive_c")
+                .join("users")
+                .join("steamuser")
+                .join("AppData")
+                .join("LocalLow");
+            let mtga_dir = locallow.join("Wizards Of The Coast").join("MTGA");
+            fs::create_dir_all(&mtga_dir)?;
+            fs::write(mtga_dir.join("Player.log"), "test")?;
+
+            let candidates = linux_candidate_base_dirs(tmp.path(), Some(&steam_lib));
+            let mtga_tail = Path::new("Wizards Of The Coast")
+                .join("MTGA")
+                .join("Player.log");
+
+            let found = candidates.iter().find(|c| c.join(&mtga_tail).exists());
+            assert!(found.is_some(), "Steam candidate should be found");
+            assert_eq!(found, Some(&locallow));
+            Ok(())
+        }
+
+        #[test]
+        fn test_linux_resolve_base_dir_lutris_fallback() -> TestResult {
+            let tmp = tempfile::tempdir()?;
+            // No steam lib; only Lutris
+            let lutris_locallow = tmp
+                .path()
+                .join("Games")
+                .join("magic-the-gathering-arena")
+                .join("drive_c")
+                .join("users")
+                .join("steamuser")
+                .join("AppData")
+                .join("LocalLow");
+            let mtga_dir = lutris_locallow.join("Wizards Of The Coast").join("MTGA");
+            fs::create_dir_all(&mtga_dir)?;
+            fs::write(mtga_dir.join("Player.log"), "test")?;
+
+            let candidates = linux_candidate_base_dirs(tmp.path(), None);
+            let mtga_tail = Path::new("Wizards Of The Coast")
+                .join("MTGA")
+                .join("Player.log");
+
+            let found = candidates.iter().find(|c| c.join(&mtga_tail).exists());
+            assert!(found.is_some(), "Lutris candidate should be found");
+            assert_eq!(found, Some(&lutris_locallow));
+            Ok(())
+        }
+
+        #[test]
+        fn test_linux_candidate_base_dirs_nothing_found_no_candidates_match() -> TestResult {
+            let tmp = tempfile::tempdir()?;
+            // No Player.log anywhere
+            let steam_lib = tmp.path().join("SteamLibrary");
+            let candidates = linux_candidate_base_dirs(tmp.path(), Some(&steam_lib));
+            let mtga_tail = Path::new("Wizards Of The Coast")
+                .join("MTGA")
+                .join("Player.log");
+
+            let found = candidates.iter().find(|c| c.join(&mtga_tail).exists());
+            assert!(
+                found.is_none(),
+                "No candidate should match when files don't exist"
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn test_linux_candidate_steam_path_contains_correct_appid() {
+            let home = PathBuf::from("/home/user");
+            let steam_lib = PathBuf::from("/home/user/.local/share/Steam");
+            let candidates = linux_candidate_base_dirs(&home, Some(&steam_lib));
+
+            assert!(!candidates.is_empty());
+            let steam_candidate = &candidates[0];
+            assert!(
+                steam_candidate.to_string_lossy().contains("2141910"),
+                "Steam candidate must use MTGA app id 2141910: {}",
+                steam_candidate.display()
+            );
+        }
+
+        #[test]
+        fn test_linux_player_log_path_helper_appends_correctly() {
+            let base = PathBuf::from("/base/LocalLow");
+            let log_path = player_log_path(&base);
+            assert_eq!(
+                log_path,
+                PathBuf::from("/base/LocalLow/Wizards Of The Coast/MTGA/Player.log")
+            );
+        }
     }
 
     #[cfg(target_os = "windows")]

--- a/src/log/discovery.rs
+++ b/src/log/discovery.rs
@@ -523,7 +523,7 @@ mod tests {
 
         type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-        /// Build the full Player.log path under a LocalLow base dir.
+        /// Build the full Player.log path under a `LocalLow` base dir.
         fn player_log_path(locallow: &Path) -> PathBuf {
             locallow
                 .join("Wizards Of The Coast")

--- a/src/log/discovery.rs
+++ b/src/log/discovery.rs
@@ -201,7 +201,7 @@ pub(crate) fn linux_candidate_base_dirs(home: &Path, steam_lib: Option<&Path>) -
         candidates.push(locallow);
     }
 
-    // Lutris (fallback, UNVERIFIED — manasight/manasight-docs#772)
+    // Lutris (fallback, UNVERIFIED)
     let lutris_locallow = home
         .join("Games")
         .join("magic-the-gathering-arena")

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -2,5 +2,7 @@
 
 pub mod discovery;
 pub mod entry;
+#[cfg(target_os = "linux")]
+mod steam;
 pub mod tailer;
 pub mod timestamp;

--- a/src/log/steam.rs
+++ b/src/log/steam.rs
@@ -1,0 +1,324 @@
+//! Steam library discovery helpers for Linux.
+//!
+//! Parses `~/.local/share/Steam/steamapps/libraryfolders.vdf` to find the
+//! Steam library that contains a given app ID, then returns the library root
+//! path.  This is required because Steam allows users to install games on
+//! any configured library disk — the default `~/.local/share/Steam` path is
+//! not guaranteed to contain a given title.
+//!
+//! The VDF format used by `libraryfolders.vdf` is a subset of Valve's
+//! `KeyValues` text format (VDF v1).  We use a hand-rolled line scanner rather
+//! than a full parser because the file is small (<100 lines), the structure
+//! is well-known, and adding a VDF crate dependency is unnecessary overhead.
+//!
+//! ## VDF structure (Steam client 2024+)
+//!
+//! ```text
+//! "libraryfolders"
+//! {
+//!     "0"
+//!     {
+//!         "path"    "/home/user/.local/share/Steam"
+//!         "apps"
+//!         {
+//!             "2141910"    "12345678"
+//!             "730"        "87654321"
+//!         }
+//!     }
+//!     "1"
+//!     {
+//!         "path"    "/mnt/games/SteamLibrary"
+//!         "apps"
+//!         {
+//!             "2141910"    "12345678"
+//!         }
+//!     }
+//! }
+//! ```
+
+use std::path::{Path, PathBuf};
+
+/// MTGA's Steam App ID.
+pub(crate) const MTGA_APP_ID: u32 = 2_141_910;
+
+/// Locate the Steam library root that contains `appid`.
+///
+/// Parses `~/.local/share/Steam/steamapps/libraryfolders.vdf` and returns the
+/// `path` value of the first library entry whose `apps` block contains the
+/// given `appid`.
+///
+/// Falls back to `~/.local/share/Steam` if:
+/// - the VDF file is missing / unreadable, **and**
+/// - `<default_steam>/steamapps/compatdata/<appid>` exists.
+///
+/// Returns `None` if neither the VDF nor the fallback resolve to a library
+/// that contains the app's `compatdata` directory.
+pub(crate) fn steam_library_for_appid(appid: u32) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    let default_steam = home.join(".local").join("share").join("Steam");
+    let vdf_path = default_steam.join("steamapps").join("libraryfolders.vdf");
+
+    // Try to parse the VDF and find the library that contains appid.
+    if vdf_path.exists() {
+        if let Ok(contents) = std::fs::read_to_string(&vdf_path) {
+            if let Some(library) = parse_library_for_appid(&contents, appid) {
+                return Some(library);
+            }
+        }
+    }
+
+    // Fallback: check the default Steam library directly.
+    let compat = default_compat_path(&default_steam, appid);
+    if compat.exists() {
+        return Some(default_steam);
+    }
+
+    None
+}
+
+/// Parse `libraryfolders.vdf` content and return the library `path` whose
+/// `apps` block contains `appid`.
+///
+/// This is a pure function (no filesystem I/O) for testability.
+pub(crate) fn parse_library_for_appid(vdf_content: &str, appid: u32) -> Option<PathBuf> {
+    let appid_str = appid.to_string();
+
+    let mut current_path: Option<String> = None;
+    let mut in_apps_block = false;
+    let mut brace_depth: u32 = 0;
+    // Depth at which the `apps` block opened (so we know when to exit it)
+    let mut apps_depth: u32 = 0;
+
+    for raw_line in vdf_content.lines() {
+        let line = raw_line.trim();
+
+        if line == "{" {
+            brace_depth += 1;
+            continue;
+        }
+
+        if line == "}" {
+            if in_apps_block && brace_depth == apps_depth {
+                // Exiting the apps block without finding the appid.
+                in_apps_block = false;
+                current_path = None;
+            }
+            brace_depth = brace_depth.saturating_sub(1);
+            continue;
+        }
+
+        if in_apps_block {
+            // Lines inside `apps { }` look like: `"<appid>"    "<bytes>"`
+            // Use full-string equality to avoid prefix collisions (e.g. "21419100").
+            if let Some(found_id) = extract_first_quoted(line) {
+                if found_id == appid_str {
+                    return current_path.map(PathBuf::from);
+                }
+            }
+            continue;
+        }
+
+        // Outside apps block: look for `"path"` and `"apps"` keys.
+        //
+        // VDF has two line shapes:
+        //   key-value: `"key"    "value"` — handled by extract_key_value
+        //   section header: `"apps"` (no value) — extract_key_value returns None
+        //     for these because there is no second quoted token; handle them
+        //     separately so that `in_apps_block` is set correctly.
+        if extract_first_quoted(line) == Some("apps") && extract_key_value(line).is_none() {
+            // The `{` for the apps block appears on the *next* line.
+            in_apps_block = true;
+            apps_depth = brace_depth + 1;
+        } else if let Some((key, value)) = extract_key_value(line) {
+            if key == "path" {
+                current_path = Some(value.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+/// Extract `("key", "value")` from a VDF line like `"key"    "value"`.
+///
+/// Returns `None` if the line doesn't match the two-token pattern.
+fn extract_key_value(line: &str) -> Option<(&str, &str)> {
+    let (key, rest) = extract_quoted_and_rest(line)?;
+    let value = extract_first_quoted(rest.trim_start())?;
+    Some((key, value))
+}
+
+/// Extract the content of the first `"..."` quoted token in `s`.
+///
+/// Returns the content *without* surrounding quotes, or `None`.
+fn extract_first_quoted(s: &str) -> Option<&str> {
+    let start = s.find('"')? + 1;
+    let end = s[start..].find('"')? + start;
+    Some(&s[start..end])
+}
+
+/// Extract the first quoted token and the remainder of the string after it.
+fn extract_quoted_and_rest(s: &str) -> Option<(&str, &str)> {
+    let open = s.find('"')? + 1;
+    let close = s[open..].find('"')? + open;
+    Some((&s[open..close], &s[close + 1..]))
+}
+
+/// Build the default compatdata path for an app under a Steam library root.
+fn default_compat_path(steam_root: &Path, appid: u32) -> PathBuf {
+    steam_root
+        .join("steamapps")
+        .join("compatdata")
+        .join(appid.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_VDF_SINGLE: &str = r#"
+"libraryfolders"
+{
+    "0"
+    {
+        "path"    "/home/user/.local/share/Steam"
+        "label"    ""
+        "contentid"    "123"
+        "totalsize"    "0"
+        "update_clean_bytes_tally"    "0"
+        "time_last_update_corruption"    "0"
+        "apps"
+        {
+            "228980"    "184139082"
+            "2141910"    "12345678"
+            "730"    "87654321"
+        }
+    }
+}
+"#;
+
+    const SAMPLE_VDF_MULTI: &str = r#"
+"libraryfolders"
+{
+    "0"
+    {
+        "path"    "/home/user/.local/share/Steam"
+        "apps"
+        {
+            "730"    "87654321"
+        }
+    }
+    "1"
+    {
+        "path"    "/mnt/games/SteamLibrary"
+        "apps"
+        {
+            "2141910"    "12345678"
+            "440"    "99999999"
+        }
+    }
+}
+"#;
+
+    const SAMPLE_VDF_NO_MTGA: &str = r#"
+"libraryfolders"
+{
+    "0"
+    {
+        "path"    "/home/user/.local/share/Steam"
+        "apps"
+        {
+            "730"    "87654321"
+        }
+    }
+}
+"#;
+
+    #[test]
+    fn test_parse_library_single_library_contains_mtga() {
+        let result = parse_library_for_appid(SAMPLE_VDF_SINGLE, 2_141_910);
+        assert_eq!(result, Some(PathBuf::from("/home/user/.local/share/Steam")));
+    }
+
+    #[test]
+    fn test_parse_library_multi_library_mtga_on_second() {
+        let result = parse_library_for_appid(SAMPLE_VDF_MULTI, 2_141_910);
+        assert_eq!(result, Some(PathBuf::from("/mnt/games/SteamLibrary")));
+    }
+
+    #[test]
+    fn test_parse_library_other_app_on_first() {
+        let result = parse_library_for_appid(SAMPLE_VDF_MULTI, 730);
+        assert_eq!(result, Some(PathBuf::from("/home/user/.local/share/Steam")));
+    }
+
+    #[test]
+    fn test_parse_library_app_not_found_returns_none() {
+        let result = parse_library_for_appid(SAMPLE_VDF_NO_MTGA, 2_141_910);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_parse_library_empty_vdf_returns_none() {
+        let result = parse_library_for_appid("", 2_141_910);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_parse_library_malformed_vdf_returns_none() {
+        let result = parse_library_for_appid("not valid vdf content !!!", 2_141_910);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_parse_library_prefix_collision_does_not_match() {
+        // "21419100" must NOT match app id 2141910 — full-string equality check.
+        const VDF_WITH_SIMILAR_ID: &str = r#"
+"libraryfolders"
+{
+    "0"
+    {
+        "path"    "/home/user/.local/share/Steam"
+        "apps"
+        {
+            "21419100"    "12345678"
+        }
+    }
+}
+"#;
+        let result = parse_library_for_appid(VDF_WITH_SIMILAR_ID, 2_141_910);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extract_first_quoted_normal() {
+        assert_eq!(extract_first_quoted(r#""hello""#), Some("hello"));
+    }
+
+    #[test]
+    fn test_extract_first_quoted_with_whitespace() {
+        assert_eq!(extract_first_quoted(r#"  "my value"   "#), Some("my value"));
+    }
+
+    #[test]
+    fn test_extract_first_quoted_no_quotes_returns_none() {
+        assert_eq!(extract_first_quoted("no quotes here"), None);
+    }
+
+    #[test]
+    fn test_extract_key_value_normal() {
+        let result = extract_key_value(r#"        "path"    "/home/user/.local/share/Steam""#);
+        assert_eq!(result, Some(("path", "/home/user/.local/share/Steam")));
+    }
+
+    #[test]
+    fn test_extract_key_value_only_key_no_value_returns_none() {
+        // A line with only one quoted token (e.g., `"apps"`) has no value.
+        let result = extract_key_value(r#"        "apps""#);
+        assert_eq!(result, None);
+    }
+}


### PR DESCRIPTION
## Summary

- Teaches `discover_log_file()` to find MTG Arena's `Player.log` on Linux via Steam/Proton (`libraryfolders.vdf` across any configured disk) with Lutris as a fallback, so a Linux parser consumer starts up instead of receiving `UnsupportedPlatform`.
- On Linux, `UnsupportedPlatform` is never returned — instead `LogFileMissing` is returned when no candidate has a `Player.log`, matching the Windows/macOS absent-file contract.
- Version bumped 0.3.0 → 0.4.0 (minor, additive new platform capability).

## Changes Made

- **New `src/log/steam.rs`**: A pure, dependency-free VDF scanner. Parses `~/.local/share/Steam/steamapps/libraryfolders.vdf` to find the Steam library containing MTGA (app id 2141910). All items `pub(crate)`. Module declared with `#[cfg(target_os = "linux")] mod steam;` in `src/log/mod.rs` — no dead code on non-Linux CI runners.
- **Linux arm in `src/log/discovery.rs`**: New `#[cfg(target_os = "linux")] fn resolve_base_dir()` tries Steam/Proton then Lutris candidates; returns `Ok(LocalLow)` for the first whose `Player.log` exists; returns `LogFileMissing` (not `UnsupportedPlatform`) when nothing found. New pure helper `linux_candidate_base_dirs(home, steam_lib)` for tempdir-testable candidate ordering without mutating `$HOME`.
- **Updated cfg fallback**: `#[cfg(not(any(target_os = "windows", target_os = "macos")))]` → `#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]`.
- **Re-gated tests**: `test_resolve_log_paths_unsupported_platform` and `test_discover_log_file_unsupported_platform` now exclude `target_os = "linux"` to avoid asserting wrong behavior.
- **Docs**: Updated `UnsupportedPlatform` doc, module doc, and `resolve_log_paths`/`discover_log_file` error docs to mention Linux.
- **CHANGELOG.md**: Added `### Added` entry under `## [Unreleased]`.
- **`Cargo.toml`**: Version 0.3.0 → 0.4.0.

## Testing

- All existing tests pass (1112 tests). `test_discover_log_file_returns_error_in_ci` is a pre-existing local failure (MTGA is installed on the dev machine; it passes in CI where MTGA is not installed — left as-is per issue instructions).
- VDF unit tests: single-library, multi-library-mtga-on-second (non-default disk), other-app-on-first, app-not-found, empty-vdf, malformed-vdf, prefix-collision guard (`21419100` must not match `2141910`), `extract_first_quoted`, `extract_key_value`.
- New Linux discovery tests against pure `linux_candidate_base_dirs` helper with tempdirs (parallel-safe, no `$HOME` mutation): Steam found; Lutris fallback; nothing-found → no candidates match.
- `cargo fmt --all -- --check` clean. `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Linux-gated code manually reviewed for clippy deny lints (no `.unwrap()`, `.expect()`, `panic!()`, `todo!()`, `dbg!()`, `println!()`). CI runs clippy on Linux.

## Stacked PR

Base: `main` — single PR in this run.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
