### PR TITLE
chore: gitignore .claude/timing-logs — stop committing timing logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ tests/smoke-results/
 # Claude Code — ignore workspace commands and runtime dirs
 .claude/commands/
 .claude/worktrees/
+# Timing logs are local-only — never commit/push them: trailing timing-log
+# commits on PR branches cancel in-flight CI and re-run the full pipeline
+# (see #218). Previously tracked logs remain in history; future logs have
+# unique names and are ignored.
+.claude/timing-logs/


### PR DESCRIPTION
## Summary

Adds `.claude/timing-logs/` to `.gitignore` so timing logs stop being committed. These logs are local-only diagnostics: trailing timing-log commits pushed to PR branches cancel in-flight CI and re-run the full pipeline, and nothing consumes the committed copies.

The already-tracked log is left in history (not `git rm`'d); future logs have unique names, so the ignore rule covers all of them.

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)