### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v26",
+    "corpus_tag": "manasight-corpus-v27",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "a9178f9"
+    "generated_from_commit": "44f20ec"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -1352,6 +1352,38 @@
       "timestamp_failures": 47,
       "total_entries": 831,
       "unclaimed": 71
+    },
+    "session_2026-06-14_1409_name-a-card.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 118,
+        "DeckCollection": 2,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameResult": 1,
+        "GameState": 563,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 2
+      },
+      "parsers": {
+        "client_actions": 118,
+        "deck_collection": 2,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 290,
+        "inventory": 2,
+        "match_state": 2,
+        "metadata": 1,
+        "rank": 2,
+        "session": 2
+      },
+      "timestamp_failures": 65,
+      "total_entries": 508,
+      "unclaimed": 89
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.