### PR TITLE
Add wasm feature: wasm-bindgen parse_whole_log artifact (manasight/manasight-docs#825)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       # It installs wasm-bindgen-cli internally and drives the full
       # wasm-bindgen test pipeline against the Node.js target.
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --locked --version 0.15.0
 
       # Run wasm-bindgen-test suite on Node.js.
       # tests/wasm_smoke.rs is gated with #![cfg(target_arch = "wasm32")]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,36 @@ jobs:
       - name: cargo check (wasm32-unknown-unknown)
         run: cargo check --target wasm32-unknown-unknown --no-default-features --features brace_depth_flush
 
+      # Also verify that the wasm feature (adds wasm-bindgen exports) compiles.
+      - name: cargo check wasm feature (wasm32-unknown-unknown)
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
+
+  wasm-smoke:
+    name: WASM smoke test (Node)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      # wasm-pack is new CI tooling introduced by this issue (#825).
+      # It installs wasm-bindgen-cli internally and drives the full
+      # wasm-bindgen test pipeline against the Node.js target.
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      # Run wasm-bindgen-test suite on Node.js.
+      # tests/wasm_smoke.rs is gated with #![cfg(target_arch = "wasm32")]
+      # so it compiles to nothing on the host and only executes here.
+      # Asserts: parse_whole_log_js(fixture) == parse_whole_log(fixture) (native parity).
+      - name: Run wasm smoke tests (Node)
+        run: wasm-pack test --node -- --no-default-features --features wasm
+
   deny:
     name: cargo deny
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +96,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -215,6 +232,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -351,6 +392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,11 +421,14 @@ dependencies = [
  "proptest",
  "regex",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "sha2",
  "tempfile",
  "thiserror",
  "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -386,6 +436,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -398,12 +458,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -411,6 +481,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pin-project-lite"
@@ -585,6 +661,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +683,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -655,6 +751,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -756,6 +858,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +896,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -819,6 +945,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6fc7a6f61926fa909ee570d4ca194e264545ebbbb4ffd63ac07ba921bff447"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f745a117245c232859f203d6c8d52c72d4cfc42de7e668c147ca6b3e45f1157e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f88e7ae201cc7c291da857532eb1c8712e89494e76ec3967b9805221388e938"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +1015,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ name = "scrub"
 path = "src/bin/scrub.rs"
 required-features = ["tailer"]
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
@@ -26,11 +29,18 @@ serde_json = "1"
 sha2 = "0.11"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "fs", "io-util", "time", "macros"], optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 known-folders = { version = "1", optional = true }
 
 [dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+# Host-only dev-dependencies: excluded from wasm32 test builds to avoid
+# platform-incompatible transitive deps (e.g. wait-timeout in tempfile).
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1"
 tempfile = "3"
 
@@ -44,6 +54,11 @@ brace_depth_flush = []
 # tokio and known-folders. Disable to build a pure-sync WASM-compatible
 # subset of the crate (see `parse_whole_log`).
 tailer = ["dep:tokio", "dep:known-folders"]
+# wasm-bindgen export of `parseWholeLog` for use in a browser/Node Parse Worker.
+# Build with: wasm-pack build --target web --no-default-features --features wasm
+# Includes brace_depth_flush for consistent flush semantics as the desktop default.
+# Does NOT pull in tailer (no tokio / known-folders), keeping the artifact wasm-safe.
+wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "brace_depth_flush"]
 
 [lints.clippy]
 # Pedantic lints as warnings

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **manasight-parser** is the log parsing engine behind [Manasight](https://manasight.gg), an MTG Arena companion app.
 
-MTG Arena log file parser — a Rust library crate that reads Arena's `Player.log` and emits typed game events via an async event bus.
+MTG Arena log file parser — a Rust library crate that reads Arena's `Player.log` and emits typed game events. It runs **natively** — tailing a live log through an async event bus — or compiles to **WebAssembly** to parse a whole log in the browser or in Node.
 
 ## Installation
 
@@ -35,8 +35,17 @@ Player.log → File Tailer → Entry Buffer → Router → Parsers → Event Bus
 - **`stream`** — public entry point (`MtgaEventStream`)
 - **`sanitize`** — privacy scrubber for redacting PII from raw log text
 - **`util`** — pipeline utilities (gzip compression, content hashing)
+- **`wasm`** — `wasm-bindgen` export of the synchronous parser (enabled by the `wasm` feature)
+
+The async pipeline above powers the live desktop overlay. The synchronous [`parse_whole_log`](#whole-log-parsing-synchronous) entry point — and its `wasm` export — reuse the same **Router → Parsers** core directly, bypassing the tailer and event bus (no `tokio`, no filesystem).
 
 ## Usage
+
+manasight-parser has two entry points: a **streaming** tailer for live logs, and a **synchronous whole-log** parser (the basis for the WASM build).
+
+### Streaming (live `Player.log`)
+
+`MtgaEventStream` (the default `tailer` feature) tails a live log and fans out events to subscribers as they arrive:
 
 ```rust
 use std::path::Path;
@@ -54,6 +63,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### Whole-log parsing (synchronous)
+
+`parse_whole_log` parses an entire `Player.log` string in one synchronous call — no async runtime, no filesystem. It is always available (independent of the `tailer` feature) and is the exact entry point the [WASM build](#wasm--wasm-bindgen-build) exposes to JavaScript:
+
+```rust
+use manasight_parser::parse_whole_log;
+
+fn main() -> std::io::Result<()> {
+    let text = std::fs::read_to_string("Player.log")?;
+    let events = parse_whole_log(&text);
+    println!("parsed {} events", events.len());
+    Ok(())
+}
+```
+
 ## Cargo Features
 
 | Feature | Default | Description |
@@ -64,11 +88,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### WASM / wasm-bindgen build
 
-The `wasm` feature produces a loadable `.wasm` artifact and JS/TypeScript bindings via [`wasm-pack`](https://rustwasm.github.io/wasm-pack/):
+The `wasm` feature wraps the synchronous [`parse_whole_log`](#whole-log-parsing-synchronous) in a [`wasm-bindgen`](https://rustwasm.github.io/wasm-bindgen/) export, producing a loadable `.wasm` artifact plus JS/TypeScript bindings via [`wasm-pack`](https://rustwasm.github.io/wasm-pack/). The *same* parser core then runs in a browser or in Node — no `tokio`, no filesystem, no async runtime.
 
 ```bash
-# Install wasm-pack (once)
-curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+# Install wasm-pack (once) — pin the version for reproducible builds
+cargo install wasm-pack --locked --version 0.15.0
 
 # Build — outputs pkg/ with .wasm + JS + .d.ts
 wasm-pack build --target web --no-default-features --features wasm
@@ -80,9 +104,26 @@ wasm-pack build --target nodejs --no-default-features --features wasm
 wasm-pack build --target bundler --no-default-features --features wasm
 ```
 
-The exported function is `parseWholeLog(input: string): GameEvent[]` — it calls the same synchronous core pipeline as the native `parse_whole_log` and returns a live JS object graph (via `serde-wasm-bindgen`), not a JSON string.
+Consume the generated bindings from JavaScript / TypeScript:
 
-**Note:** npm publishing / package distribution is out of scope for this library. The consuming application (e.g. a Parse Worker) is responsible for vendoring or packaging the built artifact.
+```js
+import init, { parseWholeLog } from "./pkg/manasight_parser.js";
+
+await init();                       // instantiate the .wasm module (web / bundler targets)
+const text = await readPlayerLog(); // the full Player.log contents, as a string
+
+let events;
+try {
+  events = parseWholeLog(text);     // GameEvent[] — see "Event Types" below
+} catch (err) {
+  // parseWholeLog throws only if serialisation to JS fails (extremely unlikely)
+  console.error("parse failed:", err);
+}
+```
+
+**Return type:** at runtime `parseWholeLog` returns a `GameEvent[]` — a live JS object graph (via [`serde-wasm-bindgen`](https://github.com/RReverser/serde-wasm-bindgen)), **not** a JSON string, so there's no second `JSON.parse`. Each element is an externally-tagged enum, e.g. `{ "GameState": { … } }` (see [Event Types](#event-types)). Because the wrapper hands back a `JsValue`, the generated `.d.ts` types the return as `any` and the call can throw — TypeScript consumers will likely want to layer their own types and a `try`/`catch`.
+
+**Distribution:** npm publishing / packaging is intentionally out of scope for this library. The consuming application (e.g. a Parse Worker) vendors or packages the built `pkg/` artifact.
 
 ## Log Sanitization
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+## Cargo Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `brace_depth_flush` | ✓ | Flush multi-line entries on JSON brace-balance instead of waiting for the next header. Disable as a rollback mechanism if a regression is detected. |
+| `tailer` | ✓ | File tailer, log discovery, async event stream (`MtgaEventStream`), and event bus. Pulls in `tokio` and `known-folders`. Disable to build the pure-sync WASM-compatible subset. |
+| `wasm` | | wasm-bindgen export of `parseWholeLog` for use in a browser or Node Parse Worker. Implies `brace_depth_flush`; does **not** pull in `tailer` (no tokio/known-folders). |
+
+### WASM / wasm-bindgen build
+
+The `wasm` feature produces a loadable `.wasm` artifact and JS/TypeScript bindings via [`wasm-pack`](https://rustwasm.github.io/wasm-pack/):
+
+```bash
+# Install wasm-pack (once)
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# Build — outputs pkg/ with .wasm + JS + .d.ts
+wasm-pack build --target web --no-default-features --features wasm
+
+# For a Node.js consumer:
+wasm-pack build --target nodejs --no-default-features --features wasm
+
+# For a bundler (webpack / Vite):
+wasm-pack build --target bundler --no-default-features --features wasm
+```
+
+The exported function is `parseWholeLog(input: string): GameEvent[]` — it calls the same synchronous core pipeline as the native `parse_whole_log` and returns a live JS object graph (via `serde-wasm-bindgen`), not a JSON string.
+
+**Note:** npm publishing / package distribution is out of scope for this library. The consuming application (e.g. a Parse Worker) is responsible for vendoring or packaging the built artifact.
+
 ## Log Sanitization
 
 The `sanitize` module strips PII and credentials from raw `Player.log` text before it leaves the user's machine. It redacts auth tokens, bearer tokens, account IDs, display names, session identifiers, OS user paths, and hardware fingerprints.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ pub mod sanitize;
 #[cfg(feature = "tailer")]
 pub mod stream;
 pub mod util;
+#[cfg(feature = "wasm")]
+pub mod wasm;
 
 // ---------------------------------------------------------------------------
 // Re-exports — public API surface

--- a/src/log/entry.rs
+++ b/src/log/entry.rs
@@ -1822,7 +1822,9 @@ mod tests {
 
     // -- Brace-depth string-literal handling (property tests) ---------------
 
-    #[cfg(feature = "brace_depth_flush")]
+    // proptest is not available for wasm32 targets (it uses host-only OS APIs);
+    // gate these tests to non-wasm host builds only.
+    #[cfg(all(feature = "brace_depth_flush", not(target_arch = "wasm32")))]
     mod brace_depth_property {
         use super::*;
         use proptest::prelude::*;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,50 @@
+//! wasm-bindgen exports for the `wasm` cargo feature.
+//!
+//! This module exposes [`parse_whole_log_js`] — a thin wrapper around the
+//! native [`crate::parse_whole_log`] — via `wasm-bindgen` so that JS/TS
+//! consumers (e.g. a Parse Worker) can call `parseWholeLog(input)` and
+//! receive a live JS object graph instead of a JSON string.
+//!
+//! # Building
+//!
+//! ```bash
+//! wasm-pack build --target web --no-default-features --features wasm
+//! ```
+//!
+//! The `wasm` feature implies `brace_depth_flush` so the artifact always has
+//! the same flush semantics as the desktop default build.
+//!
+//! # Usage from JavaScript / TypeScript
+//!
+//! ```js
+//! import init, { parseWholeLog } from './pkg/manasight_parser.js';
+//! await init();
+//! const events = parseWholeLog(logText); // returns a JS array of GameEvent objects
+//! ```
+
+use wasm_bindgen::prelude::*;
+
+/// Parses an entire MTG Arena `Player.log` string and returns a JS array of
+/// `GameEvent` objects.
+///
+/// This is the wasm-bindgen export of [`crate::parse_whole_log`].  The
+/// returned value is a live JS object graph produced by
+/// [`serde_wasm_bindgen::to_value`] — not a JSON string — so callers can
+/// access fields directly without a second `JSON.parse` round-trip.
+///
+/// # Errors
+///
+/// Returns a `JsValue` error string if serialisation to JS fails (extremely
+/// unlikely in practice, but modelled explicitly so callers can handle it).
+///
+/// # JS name
+///
+/// The JS-visible name is `parseWholeLog` (camelCase).  The Rust name
+/// (`parse_whole_log_js`) is distinct from the native `parse_whole_log` to
+/// avoid a symbol clash when the `wasm` feature is compiled on a non-wasm
+/// host (e.g. during `cargo clippy --all-features`).
+#[wasm_bindgen(js_name = parseWholeLog)]
+pub fn parse_whole_log_js(input: &str) -> Result<JsValue, JsValue> {
+    let events = crate::parse_whole_log(input);
+    serde_wasm_bindgen::to_value(&events).map_err(|e| JsValue::from_str(&e.to_string()))
+}

--- a/tests/wasm_smoke.rs
+++ b/tests/wasm_smoke.rs
@@ -15,7 +15,7 @@
 //! == native output on identical input (AC-ING-3 parity, no name
 //! special-casing required here; redaction is upstream).
 
-#![cfg(target_arch = "wasm32")]
+#![cfg(all(target_arch = "wasm32", feature = "wasm"))]
 
 use manasight_parser::{parse_whole_log, wasm::parse_whole_log_js, GameEvent};
 use wasm_bindgen_test::wasm_bindgen_test;

--- a/tests/wasm_smoke.rs
+++ b/tests/wasm_smoke.rs
@@ -1,0 +1,59 @@
+//! wasm-bindgen parity smoke test.
+//!
+//! This file is compiled **only** when targeting `wasm32` — it is a no-op on
+//! the host (macOS/Linux/Windows) so `make precommit` is unaffected.
+//!
+//! Run via:
+//! ```bash
+//! wasm-pack test --node -- --no-default-features --features wasm
+//! ```
+//!
+//! The test asserts that the wasm-bindgen wrapper [`parse_whole_log_js`]
+//! produces a JS object graph that round-trips back through
+//! `serde_wasm_bindgen::from_value` to the same `Vec<GameEvent>` that the
+//! native [`parse_whole_log`] returns on the same input — proving wasm output
+//! == native output on identical input (AC-ING-3 parity, no name
+//! special-casing required here; redaction is upstream).
+
+#![cfg(target_arch = "wasm32")]
+
+use manasight_parser::{parse_whole_log, wasm::parse_whole_log_js, GameEvent};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+// Use the gsm_with_turn_info fixture (inline to avoid I/O in wasm context).
+const FIXTURE: &str = include_str!("fixtures/gsm_with_turn_info.txt");
+
+/// Parses the corpus fixture through both code paths and asserts they agree.
+#[wasm_bindgen_test]
+fn test_parse_whole_log_js_parity_with_native() {
+    let native_events: Vec<GameEvent> = parse_whole_log(FIXTURE);
+
+    let js_value = parse_whole_log_js(FIXTURE).expect("wasm wrapper must not fail");
+
+    let wasm_events: Vec<GameEvent> =
+        serde_wasm_bindgen::from_value(js_value).expect("round-trip deserialisation must succeed");
+
+    assert_eq!(
+        native_events.len(),
+        wasm_events.len(),
+        "event count must match between native and wasm paths"
+    );
+    assert_eq!(
+        native_events, wasm_events,
+        "every event must be identical between native and wasm paths"
+    );
+}
+
+/// Sanity-check: empty input produces zero events on both paths.
+#[wasm_bindgen_test]
+fn test_parse_whole_log_js_empty_input() {
+    let native_events: Vec<GameEvent> = parse_whole_log("");
+    let js_value = parse_whole_log_js("").expect("empty input must not fail");
+    let wasm_events: Vec<GameEvent> =
+        serde_wasm_bindgen::from_value(js_value).expect("empty round-trip must succeed");
+
+    assert_eq!(
+        native_events, wasm_events,
+        "empty input must produce identical (empty) results"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds an additive, tailer-free `wasm` cargo feature that builds a wasm-bindgen artifact exposing `parseWholeLog(input: string)` over the JS boundary for the Group C Parse Worker.
- The `wasm` feature implies `brace_depth_flush` for consistent flush semantics with the desktop default; does NOT pull in `tailer` (no tokio/known-folders).

## Changes Made
- `Cargo.toml`: `[lib] crate-type = ["cdylib", "rlib"]`; optional `wasm-bindgen` + `serde-wasm-bindgen` deps; `wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "brace_depth_flush"]` feature; `wasm-bindgen-test` dev-dep; host-only gate for `proptest`/`tempfile` dev-deps to avoid wasm32 build failures.
- `src/wasm.rs`: `#[wasm_bindgen(js_name = parseWholeLog)] pub fn parse_whole_log_js(&str) -> Result<JsValue, JsValue>` → `serde_wasm_bindgen::to_value(&parse_whole_log(input))`. Returns a live JS object graph, not a JSON string. Distinct Rust name avoids symbol clash with native `parse_whole_log` during host `--all-features` builds.
- `src/lib.rs`: `#[cfg(feature = "wasm")] pub mod wasm;` declaration.
- `src/log/entry.rs`: gate `brace_depth_property` test module with `#[cfg(not(target_arch = "wasm32"))]` — proptest is host-only and does not compile to wasm32.
- `tests/wasm_smoke.rs`: `#![cfg(target_arch = "wasm32")]` parity smoke test — asserts `parse_whole_log_js(fixture) == parse_whole_log(fixture)` (wasm output == native output on identical input); two tests covering corpus fixture + empty input.
- `.github/workflows/ci.yml`: new `wasm-smoke` job (installs `wasm-pack` via curl, runs `wasm-pack test --node` — **new CI tooling**). Also adds `cargo check --features wasm` step to the existing `wasm-check` job.
- `README.md`: documented the `wasm` feature, build commands for web/nodejs/bundler targets, and the distribution note (npm packaging deferred).

## Testing
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo test --all-features`: 1139/1140 pass. The 1 failure (`test_discover_log_file_returns_error_in_ci`) is a **pre-existing failure on this dev machine** (MTGA is locally installed so `discover_log_file()` succeeds); it was failing on `main` before these changes and passes in CI where MTGA is absent.
- `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm`: compiles clean.
- `wasm-pack test --node -- --no-default-features --features wasm`: both parity smoke tests pass locally.

## Scope note
Per the pinned Definition of Done (issue option (a)), distribution (npm-publish vs. vendored `.wasm`) is **out of scope** and deferred to C-2a / a follow-up. The desktop default `["brace_depth_flush","tailer"]` build is untouched.

Closes manasight/manasight-docs#825

🤖 Generated with [Claude Code](https://claude.com/claude-code)