### PR TITLE
chore: auto-update smoke test baseline

### DIFF
--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "corpus_tag": "manasight-corpus-v32",
+    "corpus_tag": "manasight-corpus-v34",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "a147f69"
+    "generated_from_commit": "43b9b2d"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -1576,6 +1576,102 @@
       "timestamp_failures": 69,
       "total_entries": 399,
       "unclaimed": 96
+    },
+    "session_2026-06-17_1833_standard-brawl.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 347,
+        "DeckCollection": 2,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameResult": 1,
+        "GameState": 821,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 1
+      },
+      "parsers": {
+        "client_actions": 347,
+        "deck_collection": 2,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 484,
+        "inventory": 2,
+        "match_state": 2,
+        "metadata": 1,
+        "rank": 2,
+        "session": 1
+      },
+      "timestamp_failures": 83,
+      "total_entries": 966,
+      "unclaimed": 125
+    },
+    "session_2026-06-17_1847_pioneer-ranked.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 232,
+        "DeckCollection": 2,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameResult": 1,
+        "GameState": 305,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 1
+      },
+      "parsers": {
+        "client_actions": 232,
+        "deck_collection": 2,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 159,
+        "inventory": 2,
+        "match_state": 2,
+        "metadata": 1,
+        "rank": 2,
+        "session": 1
+      },
+      "timestamp_failures": 51,
+      "total_entries": 478,
+      "unclaimed": 77
+    },
+    "session_2026-06-17_1858_pioneer-ranked-bo3.log": {
+      "double_claims": 0,
+      "event_types": {
+        "ClientAction": 185,
+        "DeckCollection": 2,
+        "DetailedLoggingStatus": 1,
+        "EventLifecycle": 2,
+        "GameResult": 2,
+        "GameState": 538,
+        "Inventory": 2,
+        "MatchState": 2,
+        "Rank": 2,
+        "Session": 1
+      },
+      "parsers": {
+        "client_actions": 185,
+        "deck_collection": 2,
+        "draft_bot": 0,
+        "draft_complete": 0,
+        "draft_human": 0,
+        "event_lifecycle": 2,
+        "gre": 203,
+        "inventory": 2,
+        "match_state": 2,
+        "metadata": 1,
+        "rank": 2,
+        "session": 1
+      },
+      "timestamp_failures": 44,
+      "total_entries": 465,
+      "unclaimed": 67
     }
   }
 }


### PR DESCRIPTION
## Summary
Smoke test CI detected improved parser counts on main.
This PR updates `smoke-baseline.json` to ratchet forward to the new counts.

Auto-generated by the smoke test workflow.