### PR TITLE
chore: bump to v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.1] - 2026-06-17
+
+### Added
+
+- **`GameEvent::DeckSubmission(DeckSubmissionEvent)`** surfacing the submitted
+  deck's registered `Format` and `DeckId` from `EventSetDeckV2` / `EventSetDeckV3`
+  request lines. A new family-matched parser claims the bare `==> EventSetDeck`
+  prefix — covering V2, V3, and any future `Vn` without panicking on an
+  unrecognized version — decodes the double-encoded `request`, and emits a
+  `{ metadata, payload }` event whose payload carries
+  `{ deck_id, deck_format, event_name, is_singleton }`. This gives the format
+  model a precise fallback for generic / bot-match queues whose event name is not
+  format-bearing. `GameEvent` is `#[non_exhaustive]`, so the new variant is
+  additive (#232, #237).
+
 ## [0.5.0] - 2026-06-16
 
 > Released directly from `0.3.0`. Versions `0.4.0` and `0.5.0` were bumped in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "manasight-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump `manasight-parser` from **0.5.0 → 0.5.1** in preparation for crates.io publish
- **Patch** release: additive-only public-API change on the `#[non_exhaustive]` `GameEvent` enum, no breaking changes

## Changes since v0.5.0

**Added**
- `GameEvent::DeckSubmission(DeckSubmissionEvent)` — the `EventSetDeck` deck-Format parser (registered deck `Format` + `DeckId` from `EventSetDeckV2`/`V3` requests; payload `{ deck_id, deck_format, event_name, is_singleton }`). Additive variant on a `#[non_exhaustive]` enum (#232, #237).

**Internal** (no public-API delta)
- Smoke-baseline auto-updates (#233, #234).

## Test plan

- [x] `cargo check` clean; `Cargo.lock` refreshed to 0.5.1
- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 1164 passed (lone local `test_discover_log_file_returns_error_in_ci` failure is the known MTGA-installed env case; green in CI)
- [ ] CI green
- [ ] After merge: tag `v0.5.1` and trigger the publish-crate workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)