### PR TITLE
chore: bump to v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.2] - 2026-06-19
+
+### Fixed
+
+- **`parse_whole_log` now parses logs from the newer MTGA Mac client** that
+  prefixes every line with a Unity frame counter
+  (`[<frame>] [UnityCrossThreadLogger]…`, the uploaded `UTC_Log` archive
+  variant). Header and metadata detection is anchored at byte 0, so these
+  otherwise-valid logs produced **0 events**. `LineBuffer::push_line` now strips
+  an optional leading `[<digits>] ` prefix before detection — a single chokepoint
+  covering every byte-0-anchored detector. Output is byte-identical for
+  unprefixed input across the full corpus, so the live `Player.log` path is
+  unaffected (#240, #241).
+
 ## [0.5.1] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "manasight-parser"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump `manasight-parser` from **0.5.1 → 0.5.2** in preparation for crates.io publish
- Patch release: one behavioral bug fix with **no public-API change**

## Changes since v0.5.1

**Fixed**
- `parse_whole_log` now parses logs from the newer MTGA Mac client that prefix every line with a Unity frame counter (`[<frame>] [UnityCrossThreadLogger]…`, the uploaded `UTC_Log` archive variant) — previously 0 events. `LineBuffer::push_line` strips an optional leading `[<digits>] ` prefix before byte-0-anchored detection. Output is byte-identical for unprefixed input, so the live `Player.log` path is unaffected (#240, #241).

**Internal**
- Corpus smoke-baseline auto-updates (#236, #239).

## Test plan

- [x] `cargo check` clean (Cargo.lock refreshed to 0.5.2)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 1174 pass (lone `test_discover_log_file_returns_error_in_ci` fails only locally on an MTGA-installed Mac; passes in CI)
- [ ] CI green
- [ ] After merge: tag `v0.5.2` and trigger publish-crate workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)