### PR TITLE
chore: bump to v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.3] - 2026-06-19
+
+### Fixed
+
+- **`parse_whole_log_js` (WASM) now serializes event payloads as plain JS
+  objects instead of `Map` instances.** The wasm-bindgen export used the default
+  `serde_wasm_bindgen` serializer, which emits dynamic `serde_json::Value`
+  objects — every `payload` and nested dynamic object — as JS `Map`s, so JS/TS
+  consumers reading fields by property access (`payload.match_id`) got
+  `undefined` and had to fall back to `.get(...)`. This diverged from the native
+  `serde_json` output. The serializer is now configured with
+  `serialize_maps_as_objects(true)`, so WASM output matches the native
+  plain-object shape and the documented externally-tagged event contract. Only
+  WASM consumers were affected; native Rust output is unchanged (#243, #244).
+
 ## [0.5.2] - 2026-06-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "manasight-parser"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump `manasight-parser` from **0.5.2 → 0.5.3** in preparation for crates.io publish
- Patch release: a WASM behavioral bug fix with no Rust public-API surface change

## Changes since v0.5.2

**Fixed**
- `parse_whole_log_js` (WASM) now serializes event payloads as plain JS objects instead of `Map` instances (`serialize_maps_as_objects(true)`), matching the native `serde_json` output and the documented externally-tagged event contract. Only WASM consumers were affected; native Rust output is unchanged (#243, #244).

## Test plan

- [x] `cargo check` clean; `Cargo.lock` refreshed to 0.5.3
- [x] `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` clean locally (sole failure is the known-environmental `test_discover_log_file_returns_error_in_ci`)
- [ ] CI green (clippy + tests + fmt + wasm)
- [ ] After merge: tag `v0.5.3` and trigger publish-crate workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)