### PR TITLE
chore: bump to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.0] - 2026-06-20
+
+### Added
+
+- **`EventMetadata::instant_utc()`** — returns the true UTC instant for events
+  carrying an embedded epoch-millisecond `"timestamp"` (currently
+  match-lifecycle events from `matchGameRoomStateChangedEvent`). Unlike the
+  log-header timestamp, this is timezone-independent and correct regardless of
+  the host's local zone (including the `wasm`/headless build). Returns `None`
+  for events without an embedded epoch-ms field ([#251], [#252]).
+- **`EventMetadata::local_timestamp()`** — returns the log-header timestamp as a
+  zone-less `chrono::NaiveDateTime`, the honest representation of MTGA's local
+  wall-clock header value ([#251], [#252]).
+- **`EventMetadata::with_instant()`** — constructor that accepts both the header
+  timestamp and an `instant_utc` value ([#251], [#252]).
+
+### Changed
+
+- **`EventMetadata::timestamp()` is now `#[deprecated]`.** MTGA log-header
+  timestamps are local wall-clock time mislabeled as UTC (the inner
+  `NaiveDateTime` is promoted with `.and_utc()`). Use `instant_utc()` for the
+  absolute UTC instant, or `local_timestamp()` for the honest zone-less local
+  value. The accessor still works unchanged; this release only adds the
+  deprecation warning ([#251], [#252]).
+- Corrected the `src/log/timestamp.rs` documentation, which previously claimed
+  log-header timestamps were UTC ([#251], [#252]).
+
+### Notes
+
+- This release is **additive and backward-compatible**. Serialized payloads
+  round-trip with and without the new `instant_utc` field (`#[serde(default)]`).
+  Wiring `instant_utc` for `.NET-ticks` events (e.g. `client_actions`) is
+  deferred to a future release.
+
+[#251]: https://github.com/manasight/manasight-parser/issues/251
+[#252]: https://github.com/manasight/manasight-parser/pull/252
+
 ## [0.5.3] - 2026-06-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "manasight-parser"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or in `Cargo.toml`:
 
 ```toml
 [dependencies]
-manasight-parser = "0.5"
+manasight-parser = "0.6"
 ```
 
 Requires Rust 1.93.0 or later.


### PR DESCRIPTION
## Summary

- Bump `manasight-parser` from **0.5.3 → 0.6.0** in preparation for crates.io publish
- **Minor** release: adds new public `EventMetadata` timestamp API (from #251 / #252) and deprecates the mislabeled `timestamp()` accessor — additive and backward-compatible

## Changes since v0.5.3

**Added**
- `EventMetadata::instant_utc()` — true UTC instant from the embedded epoch-ms field (match-lifecycle events); timezone-independent (correct under wasm/headless)
- `EventMetadata::local_timestamp()` — log-header value as a zone-less `NaiveDateTime`
- `EventMetadata::with_instant()` — constructor accepting `instant_utc`

**Changed**
- `EventMetadata::timestamp()` is now `#[deprecated]` (still works) — header timestamps are local wall-clock mislabeled as UTC
- Corrected `src/log/timestamp.rs` docs that wrongly claimed headers are UTC

## Test plan

- [x] `cargo check` clean; `Cargo.lock` refreshed to 0.6.0
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 1184 pass (lone `test_discover_log_file_returns_error_in_ci` is a known local-env failure, passes in CI)
- [ ] CI green
- [ ] After merge: tag `v0.6.0` and trigger publish-crate workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)