### PR TITLE
Fix #254: incremental StreamingParser + lean Cargo feature

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -103,7 +103,7 @@ jobs:
           # pipefail is load-bearing: without it, tee's exit 0 masks cargo test failures.
           set -o pipefail
           set +e
-          cargo test --all-features smoke_test_real_logs -- --nocapture 2>&1 | tee /tmp/smoke-output.txt
+          cargo test smoke_test_real_logs -- --nocapture 2>&1 | tee /tmp/smoke-output.txt
           SMOKE_EXIT=$?
           set -e
 
@@ -225,7 +225,7 @@ jobs:
           GH_TOKEN: ${{ secrets.BASELINE_PR_TOKEN }}
         run: |
           # Re-run in bless mode to write updated baseline.
-          if ! cargo test --all-features smoke_test_real_logs -- --nocapture 2>&1; then
+          if ! cargo test smoke_test_real_logs -- --nocapture 2>&1; then
             echo "::warning::Bless mode run exited non-zero — baseline may not have been updated"
           fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,18 @@ brace_depth_flush = []
 # tokio and known-folders. Disable to build a pure-sync WASM-compatible
 # subset of the crate (see `parse_whole_log`).
 tailer = ["dep:tokio", "dep:known-folders"]
-# wasm-bindgen export of `parseWholeLog` for use in a browser/Node Parse Worker.
-# Build with: wasm-pack build --target web --no-default-features --features wasm
+# Lean serialization: omits `raw_bytes` from EventMetadata and drops heavy payload
+# fields (annotations, game objects, zones, etc.) that the WASM consumer does not
+# use. The default/native build is byte-identical when this feature is disabled.
+# `raw_bytes_hash` is always retained for server-side event deduplication.
+lean = []
+# wasm-bindgen export of `parseWholeLog` and `StreamingParser` for use in a
+# browser/Node Parse Worker.
+# Build with: wasm-pack build --target bundler --no-default-features --features wasm
 # Includes brace_depth_flush for consistent flush semantics as the desktop default.
+# Automatically enables `lean` to minimize WASM memory usage.
 # Does NOT pull in tailer (no tokio / known-folders), keeping the artifact wasm-safe.
-wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "brace_depth_flush"]
+wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "brace_depth_flush", "lean"]
 
 [lints.clippy]
 # Pedantic lints as warnings

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ fn main() -> std::io::Result<()> {
 |---------|---------|-------------|
 | `brace_depth_flush` | ✓ | Flush multi-line entries on JSON brace-balance instead of waiting for the next header. Disable as a rollback mechanism if a regression is detected. |
 | `tailer` | ✓ | File tailer, log discovery, async event stream (`MtgaEventStream`), and event bus. Pulls in `tokio` and `known-folders`. Disable to build the pure-sync WASM-compatible subset. |
-| `wasm` | | wasm-bindgen export of `parseWholeLog` for use in a browser or Node Parse Worker. Implies `brace_depth_flush`; does **not** pull in `tailer` (no tokio/known-folders). |
+| `wasm` | | wasm-bindgen export of `parseWholeLog` and `StreamingParser` for use in a browser or Node Parse Worker. Implies `brace_depth_flush` and `lean` (omits `raw_bytes` + heavy payload fields such as annotations, timers, zones, and deck lists to reduce WASM memory pressure). Does **not** pull in `tailer` (no tokio/known-folders). |
 
 ### WASM / wasm-bindgen build
 
@@ -94,14 +94,14 @@ The `wasm` feature wraps the synchronous [`parse_whole_log`](#whole-log-parsing-
 # Install wasm-pack (once) — pin the version for reproducible builds
 cargo install wasm-pack --locked --version 0.15.0
 
-# Build — outputs pkg/ with .wasm + JS + .d.ts
-wasm-pack build --target web --no-default-features --features wasm
+# Build for a bundler (webpack / Vite) — PRIMARY/recommended target:
+wasm-pack build --target bundler --no-default-features --features wasm
 
 # For a Node.js consumer:
 wasm-pack build --target nodejs --no-default-features --features wasm
 
-# For a bundler (webpack / Vite):
-wasm-pack build --target bundler --no-default-features --features wasm
+# For direct <script type="module"> usage (no bundler):
+wasm-pack build --target web --no-default-features --features wasm
 ```
 
 Consume the generated bindings from JavaScript / TypeScript:

--- a/src/events.rs
+++ b/src/events.rs
@@ -18,11 +18,15 @@ use sha2::{Digest, Sha256};
 /// Serialize `Vec<u8>` as a base64 string (RFC 4648 standard alphabet).
 mod base64_serde {
     use base64::prelude::{Engine as _, BASE64_STANDARD};
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::{Deserialize, Deserializer};
 
+    // `serialize` is only referenced by `EventMetadata`'s `Serialize` impl for the
+    // `raw_bytes` field. Under the `lean` feature, that field is `skip_serializing`,
+    // so the serializer is never called — gate the function accordingly.
+    #[cfg(not(feature = "lean"))]
     pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         serializer.serialize_str(&BASE64_STANDARD.encode(bytes))
     }
@@ -427,6 +431,10 @@ pub struct EventMetadata {
 
     /// Original log entry bytes, serialized as base64. Private to prevent
     /// mutation that would break the `raw_bytes_hash` invariant.
+    ///
+    /// Under the `lean` feature this field is omitted from serialized output
+    /// (but `raw_bytes_hash` is always retained for server-side deduplication).
+    #[cfg_attr(feature = "lean", serde(skip_serializing))]
     #[serde(with = "base64_serde")]
     raw_bytes: Vec<u8>,
 
@@ -548,7 +556,13 @@ impl<'de> Deserialize<'de> for EventMetadata {
             timestamp: Option<DateTime<Utc>>,
             #[serde(default)]
             instant_utc: Option<DateTime<Utc>>,
-            #[serde(with = "base64_serde")]
+            /// `raw_bytes` may be absent when deserializing a lean-serialized
+            /// event (the `lean` feature skips this field). `#[serde(default)]`
+            /// causes serde to use `Vec::default()` (empty) when the field is
+            /// absent, preserving round-trip compatibility without requiring a
+            /// custom deserializer. Consumers that need the original bytes must
+            /// use the non-lean build.
+            #[serde(default, with = "base64_serde")]
             raw_bytes: Vec<u8>,
             // Accepts any format (hex string, integer array) or absence.
             // The value is discarded — hash is always recomputed.
@@ -1324,7 +1338,12 @@ mod tests {
     }
 
     // -- Serialization round-trip --
+    // Under `lean`, `raw_bytes` is skip_serializing, so the serialized
+    // output does not contain `raw_bytes`. The deserialized metadata will
+    // have empty `raw_bytes` (and thus a different hash), making these
+    // round-trip equality checks invalid under lean. Gate them accordingly.
 
+    #[cfg(not(feature = "lean"))]
     #[test]
     fn test_game_event_serde_round_trip_all_variants() -> TestResult {
         for event in all_variants() {
@@ -1335,6 +1354,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(feature = "lean"))]
     #[test]
     fn test_event_metadata_serde_round_trip() -> TestResult {
         let meta = make_metadata(b"round trip test");
@@ -1345,6 +1365,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(feature = "lean"))]
     #[test]
     fn test_event_metadata_deserialize_recomputes_hash() -> TestResult {
         let meta = make_metadata(b"test data");
@@ -1378,6 +1399,9 @@ mod tests {
 
     // -- Wire format --
 
+    /// Under lean, `raw_bytes` is skipped during serialization; this test
+    /// only makes sense for the non-lean build where raw_bytes is present.
+    #[cfg(not(feature = "lean"))]
     #[test]
     fn test_event_metadata_serializes_raw_bytes_as_base64() -> TestResult {
         let meta = make_metadata(b"hello world");
@@ -1431,6 +1455,9 @@ mod tests {
         Ok(())
     }
 
+    /// Under lean, `raw_bytes` is skipped in serialized output so the
+    /// round-trip equality check does not hold. Gate under not(lean).
+    #[cfg(not(feature = "lean"))]
     #[test]
     fn test_event_metadata_none_timestamp_serde_round_trip() -> TestResult {
         let meta = EventMetadata::new(None, b"no timestamp".to_vec());
@@ -1455,6 +1482,9 @@ mod tests {
 
     // -- instant_utc serde round-trips -----------------------------------------
 
+    /// Under lean, `raw_bytes` is skipped in serialized output; gate the
+    /// round-trip equality check accordingly.
+    #[cfg(not(feature = "lean"))]
     #[test]
     fn test_event_metadata_with_instant_utc_serde_round_trip() -> TestResult {
         // A payload WITH instant_utc must survive a full serialize → deserialize

--- a/src/events.rs
+++ b/src/events.rs
@@ -407,6 +407,16 @@ impl PerformanceClass {
 ///
 /// Deserialization also enforces this invariant: the hash is recomputed from
 /// `raw_bytes` during deserialization rather than trusting the serialized value.
+///
+/// **Caveat under `lean`:** The `lean` feature omits `raw_bytes` from
+/// serialized output (`skip_serializing`). If a lean-serialized `EventMetadata`
+/// is Rust-deserialized (e.g. in tests using `serde_wasm_bindgen::from_value`),
+/// the custom `Deserialize` impl recomputes `raw_bytes_hash` from the
+/// now-empty `raw_bytes`, yielding a hash of the empty byte slice rather than
+/// the original. Production JS consumers read the correctly-serialized wire
+/// hash (computed at parse time from the real bytes) and are unaffected.
+/// To avoid this, compare serialized `serde_json::Value` forms rather than
+/// round-tripping through the typed `Deserialize` impl under `lean`.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct EventMetadata {
     /// Local wall-clock timestamp parsed from the log entry header, stored
@@ -557,12 +567,14 @@ impl<'de> Deserialize<'de> for EventMetadata {
             #[serde(default)]
             instant_utc: Option<DateTime<Utc>>,
             /// `raw_bytes` may be absent when deserializing a lean-serialized
-            /// event (the `lean` feature skips this field). `#[serde(default)]`
-            /// causes serde to use `Vec::default()` (empty) when the field is
-            /// absent, preserving round-trip compatibility without requiring a
-            /// custom deserializer. Consumers that need the original bytes must
-            /// use the non-lean build.
-            #[serde(default, with = "base64_serde")]
+            /// event (the `lean` feature skips this field on serialization).
+            /// Under `lean`, `#[serde(default)]` causes serde to use
+            /// `Vec::default()` (empty) when the field is absent, preserving
+            /// round-trip compatibility. Under non-lean (the default build),
+            /// the field is strictly required, preserving the hash invariant
+            /// and catching truncated/malformed payloads at deserialization time.
+            #[cfg_attr(feature = "lean", serde(default))]
+            #[serde(with = "base64_serde")]
             raw_bytes: Vec<u8>,
             // Accepts any format (hex string, integer array) or absence.
             // The value is discarded — hash is always recomputed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,8 @@ pub mod sanitize;
 #[cfg(feature = "tailer")]
 pub mod stream;
 pub mod util;
-#[cfg(feature = "wasm")]
+// The `wasm` module always exposes `StreamingParserCore` for host-side tests.
+// The `#[wasm_bindgen]` exports within are gated on the `wasm` feature.
 pub mod wasm;
 
 // ---------------------------------------------------------------------------

--- a/src/parsers/deck_collection.rs
+++ b/src/parsers/deck_collection.rs
@@ -71,14 +71,32 @@ pub fn try_parse(
     }
 
     let parsed = api_common::parse_json_from_body(body, "StartHook deck collection")?;
-    let deck_summaries = parsed.get(DECK_SUMMARIES_FIELD)?.as_array()?;
-    let decks = parsed.get(DECKS_FIELD)?.as_object()?;
 
-    let payload = serde_json::json!({
-        "type": "deck_collection_snapshot",
-        "decks": correlate_decks(deck_summaries, decks),
-        "raw_start_hook": parsed,
-    });
+    // Under the `lean` feature, drop `raw_start_hook` (the full StartHook
+    // JSON, ~large) and the `decks` payload (deck lists, also large).
+    // Keep the variant envelope key (`type`) so consumers doing
+    // `Object.keys(e)[0]` still see `DeckCollection`.
+    //
+    // We must still validate that DeckSummaries and Decks are present (to
+    // match/not-match correctly) but we don't build the correlated payload.
+    #[cfg(feature = "lean")]
+    let payload = {
+        // Validate presence of required fields for entry-matching purposes.
+        let _deck_summaries = parsed.get(DECK_SUMMARIES_FIELD)?.as_array()?;
+        let _decks = parsed.get(DECKS_FIELD)?.as_object()?;
+        serde_json::json!({ "type": "deck_collection_snapshot" })
+    };
+
+    #[cfg(not(feature = "lean"))]
+    let payload = {
+        let deck_summaries = parsed.get(DECK_SUMMARIES_FIELD)?.as_array()?;
+        let decks = parsed.get(DECKS_FIELD)?.as_object()?;
+        serde_json::json!({
+            "type": "deck_collection_snapshot",
+            "decks": correlate_decks(deck_summaries, decks),
+            "raw_start_hook": parsed,
+        })
+    };
 
     let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
     Some(GameEvent::DeckCollection(DeckCollectionEvent::new(
@@ -87,6 +105,8 @@ pub fn try_parse(
 }
 
 /// Correlates `DeckSummaries` entries with `Decks` payloads by `DeckId`.
+/// Not compiled under the `lean` feature (deck list data is excluded from the lean payload).
+#[cfg(not(feature = "lean"))]
 fn correlate_decks(
     deck_summaries: &[serde_json::Value],
     decks: &serde_json::Map<String, serde_json::Value>,
@@ -100,6 +120,8 @@ fn correlate_decks(
 }
 
 /// Builds a single correlated deck record from a summary and deck-map lookup.
+/// Not compiled under the `lean` feature.
+#[cfg(not(feature = "lean"))]
 fn correlate_summary(
     summary: &serde_json::Value,
     deck_map: &serde_json::Map<String, serde_json::Value>,
@@ -124,10 +146,15 @@ fn correlate_summary(
 mod tests {
     use super::*;
     use crate::events::PerformanceClass;
-    use crate::parsers::test_helpers::{deck_collection_payload, test_timestamp, unity_entry};
+    use crate::parsers::test_helpers::{test_timestamp, unity_entry};
+    // `deck_collection_payload` is only referenced by the `matching` sub-module,
+    // which is gated under `not(lean)`.
+    #[cfg(not(feature = "lean"))]
+    use crate::parsers::test_helpers::deck_collection_payload;
 
-    // -- Matching entries (StartHook with DeckSummaries and Decks) ------------
+    // -- Matching entries (not compiled under `lean` — deck payload excluded) --
 
+    #[cfg(not(feature = "lean"))]
     mod matching {
         use super::*;
 

--- a/src/parsers/deck_collection.rs
+++ b/src/parsers/deck_collection.rs
@@ -60,6 +60,10 @@ const DECKS_FIELD: &str = "Decks";
 /// The `timestamp` is `None` when the log entry header did not contain a
 /// parseable timestamp. It is passed through to [`EventMetadata`] so
 /// downstream consumers can distinguish real vs missing timestamps.
+///
+/// Under the `lean` feature, `raw_start_hook` and `decks` are omitted from
+/// the emitted event payload; only the `type` envelope remains. Consumers
+/// that need the full deck data must use the non-lean build.
 pub fn try_parse(
     entry: &LogEntry,
     timestamp: Option<chrono::DateTime<chrono::Utc>>,

--- a/src/parsers/gre/game_result.rs
+++ b/src/parsers/gre/game_result.rs
@@ -658,6 +658,8 @@ mod tests {
     /// `GameResult` so annotation-walker consumers see the killing-blow data.
     mod game_over_dual_emit {
         use super::*;
+        // `game_state_payload` is only used by lean-gated tests.
+        #[cfg(not(feature = "lean"))]
         use crate::parsers::test_helpers::game_state_payload;
 
         /// Body: `GameOver` GSM with a non-empty `annotations` array carrying
@@ -748,6 +750,8 @@ mod tests {
             );
         }
 
+        // Under `lean`, annotations are excluded from the GameState payload.
+        #[cfg(not(feature = "lean"))]
         #[test]
         fn test_game_state_carries_killing_damage_annotations() {
             let entry = unity_entry(&game_over_body_with_killing_damage());
@@ -792,6 +796,8 @@ mod tests {
             assert!(matches!(events[0], GameEvent::GameResult(_)));
         }
 
+        // Under `lean`, persistent_annotations are excluded from payload.
+        #[cfg(not(feature = "lean"))]
         #[test]
         fn test_game_over_persistent_annotations_only_still_emits_game_state() {
             // Persistent annotations alone (no regular annotations) are also

--- a/src/parsers/gre/game_state.rs
+++ b/src/parsers/gre/game_state.rs
@@ -38,6 +38,12 @@ use super::turn_info::extract_turn_info;
 /// `timers`, and `diff_deleted_instance_ids` are empty arrays when their
 /// respective source arrays are absent.
 ///
+/// Under the `lean` feature, the payload omits `annotations`,
+/// `game_objects`, `timers`, `zones`, and `persistent_annotations` to reduce
+/// WASM memory pressure. Only `type`, `game_state_type`, `msg_id`,
+/// `game_state_id`, `prev_game_state_id`, `game_info`, `turn_info`, and
+/// `diff_deleted_instance_ids` are retained.
+///
 /// `prev_game_state_id` is the `prevGameStateId` field present on every Diff
 /// GSM wire payload. Full GSMs legitimately omit it; the extracted value is
 /// `Option<i64>` and serializes to JSON `null` when absent. Surfacing this

--- a/src/parsers/gre/game_state.rs
+++ b/src/parsers/gre/game_state.rs
@@ -1,6 +1,10 @@
 //! `GameStateMessage` and `QueuedGameStateMessage` payload builder.
 
+// Under `lean`, annotations/zones/game_objects are omitted from the payload
+// so these extraction functions are not referenced.
+#[cfg(not(feature = "lean"))]
 use super::annotations::{extract_annotations, extract_persistent_annotations};
+#[cfg(not(feature = "lean"))]
 use super::helpers::{extract_nested_value, extract_string_array};
 use super::turn_info::extract_turn_info;
 
@@ -81,28 +85,31 @@ pub(super) fn build_game_state_message_payload(gre_msg: &serde_json::Value) -> s
         .and_then(serde_json::Value::as_str)
         .map(String::from);
 
-    // Extract zones from gameStateMessage.zones[].
-    let zones = extract_zones(gsm);
-
-    // Extract game objects from gameStateMessage.gameObjects[].
-    let game_objects = extract_game_objects(gsm);
-
-    // Extract game info metadata.
+    // Extract game info metadata (kept under all feature configurations).
     let game_info = gsm
         .and_then(|g| g.get("gameInfo"))
         .cloned()
         .unwrap_or(serde_json::Value::Null);
 
-    // Extract structured turn info from gameInfo.turnInfo.
+    // Extract structured turn info from gameInfo.turnInfo (kept under all configs).
     let turn_info = extract_turn_info(gsm);
 
-    // Extract annotations from gameStateMessage.annotations[].
+    // Under the `lean` feature, high-volume fields (zones, game objects,
+    // annotations, timers) are excluded from the payload to reduce WASM memory
+    // usage. They are extracted only for the non-lean build.
+    #[cfg(not(feature = "lean"))]
+    let zones = extract_zones(gsm);
+
+    #[cfg(not(feature = "lean"))]
+    let game_objects = extract_game_objects(gsm);
+
+    #[cfg(not(feature = "lean"))]
     let annotations = extract_annotations(gsm);
 
-    // Extract persistent annotations from gameStateMessage.persistentAnnotations[].
+    #[cfg(not(feature = "lean"))]
     let persistent_annotations = extract_persistent_annotations(gsm);
 
-    // Extract inline timers from gameStateMessage.timers[].
+    #[cfg(not(feature = "lean"))]
     let timers = extract_timers(gsm);
 
     // Extract diffDeletedInstanceIds (instance IDs removed from game state).
@@ -116,21 +123,41 @@ pub(super) fn build_game_state_message_payload(gre_msg: &serde_json::Value) -> s
         })
         .unwrap_or_default();
 
-    serde_json::json!({
-        "type": payload_type,
-        "game_state_type": game_state_type,
-        "msg_id": msg_id,
-        "game_state_id": game_state_id,
-        "prev_game_state_id": prev_game_state_id,
-        "zones": zones,
-        "game_objects": game_objects,
-        "game_info": game_info,
-        "turn_info": turn_info,
-        "annotations": annotations,
-        "persistent_annotations": persistent_annotations,
-        "timers": timers,
-        "diff_deleted_instance_ids": diff_deleted_instance_ids,
-    })
+    // Under the `lean` feature, drop high-volume fields (annotations, game
+    // objects, timers, zones) that the WASM consumer does not use, keeping
+    // only the fields needed for result-focused consumers (type, ids,
+    // game_info, turn_info, diff_deleted_instance_ids).
+    #[cfg(feature = "lean")]
+    {
+        serde_json::json!({
+            "type": payload_type,
+            "game_state_type": game_state_type,
+            "msg_id": msg_id,
+            "game_state_id": game_state_id,
+            "prev_game_state_id": prev_game_state_id,
+            "game_info": game_info,
+            "turn_info": turn_info,
+            "diff_deleted_instance_ids": diff_deleted_instance_ids,
+        })
+    }
+    #[cfg(not(feature = "lean"))]
+    {
+        serde_json::json!({
+            "type": payload_type,
+            "game_state_type": game_state_type,
+            "msg_id": msg_id,
+            "game_state_id": game_state_id,
+            "prev_game_state_id": prev_game_state_id,
+            "zones": zones,
+            "game_objects": game_objects,
+            "game_info": game_info,
+            "turn_info": turn_info,
+            "annotations": annotations,
+            "persistent_annotations": persistent_annotations,
+            "timers": timers,
+            "diff_deleted_instance_ids": diff_deleted_instance_ids,
+        })
+    }
 }
 
 /// Extracts timer data from the `gameStateMessage.timers` array.
@@ -140,6 +167,8 @@ pub(super) fn build_game_state_message_payload(gre_msg: &serde_json::Value) -> s
 /// are normalized to `snake_case`.
 ///
 /// Returns an empty `Vec` when `timers` is absent or empty.
+/// Not compiled under the `lean` feature (timers are excluded from the lean payload).
+#[cfg(not(feature = "lean"))]
 fn extract_timers(gsm: Option<&serde_json::Value>) -> Vec<serde_json::Value> {
     let Some(raw_timers) = gsm
         .and_then(|g| g.get("timers"))
@@ -152,6 +181,8 @@ fn extract_timers(gsm: Option<&serde_json::Value>) -> Vec<serde_json::Value> {
 }
 
 /// Extracts a single timer, normalizing field names to `snake_case`.
+/// Not compiled under the `lean` feature.
+#[cfg(not(feature = "lean"))]
 fn extract_single_timer(timer: &serde_json::Value) -> Option<serde_json::Value> {
     let timer_id = timer.get("timerId").and_then(serde_json::Value::as_i64)?;
 
@@ -202,6 +233,7 @@ fn extract_single_timer(timer: &serde_json::Value) -> Option<serde_json::Value> 
 }
 
 /// Extracts zone descriptors from the `gameStateMessage.zones` array.
+/// Not compiled under the `lean` feature (zones are excluded from the lean payload).
 ///
 /// Each zone in the MTGA log has the structure:
 /// ```json
@@ -216,6 +248,7 @@ fn extract_single_timer(timer: &serde_json::Value) -> Option<serde_json::Value> 
 ///
 /// The output normalizes field names to `snake_case` for consistency
 /// with the rest of the parser output.
+#[cfg(not(feature = "lean"))]
 fn extract_zones(gsm: Option<&serde_json::Value>) -> Vec<serde_json::Value> {
     let Some(raw_zones) = gsm
         .and_then(|g| g.get("zones"))
@@ -228,6 +261,8 @@ fn extract_zones(gsm: Option<&serde_json::Value>) -> Vec<serde_json::Value> {
 }
 
 /// Extracts a single zone descriptor, normalizing field names to `snake_case`.
+/// Not compiled under the `lean` feature.
+#[cfg(not(feature = "lean"))]
 fn extract_single_zone(zone: &serde_json::Value) -> Option<serde_json::Value> {
     let zone_id = zone.get("zoneId").and_then(serde_json::Value::as_i64)?;
     let zone_type = zone
@@ -265,6 +300,7 @@ fn extract_single_zone(zone: &serde_json::Value) -> Option<serde_json::Value> {
 }
 
 /// Extracts game object descriptors from the `gameStateMessage.gameObjects` array.
+/// Not compiled under the `lean` feature (game objects are excluded from the lean payload).
 ///
 /// Each game object in the MTGA log has the structure:
 /// ```json
@@ -286,6 +322,7 @@ fn extract_single_zone(zone: &serde_json::Value) -> Option<serde_json::Value> {
 ///
 /// The output normalizes field names to `snake_case`. Not all fields are
 /// present in every object (incremental updates, non-card types, etc.).
+#[cfg(not(feature = "lean"))]
 fn extract_game_objects(gsm: Option<&serde_json::Value>) -> Vec<serde_json::Value> {
     let Some(raw_objects) = gsm
         .and_then(|g| g.get("gameObjects"))
@@ -301,6 +338,8 @@ fn extract_game_objects(gsm: Option<&serde_json::Value>) -> Vec<serde_json::Valu
 }
 
 /// Extracts a single game object, normalizing field names to `snake_case`.
+/// Not compiled under the `lean` feature.
+#[cfg(not(feature = "lean"))]
 fn extract_single_game_object(obj: &serde_json::Value) -> Option<serde_json::Value> {
     let instance_id = obj.get("instanceId").and_then(serde_json::Value::as_i64)?;
 
@@ -413,11 +452,16 @@ fn extract_single_game_object(obj: &serde_json::Value) -> Option<serde_json::Val
 mod tests {
     use super::super::test_fixtures::*;
     use super::super::try_parse;
+    // Under `lean`, zone/object/timer extraction functions are cfg'd away;
+    // the glob import would be empty and trigger an unused-import warning.
+    #[cfg(not(feature = "lean"))]
     use super::*;
     use crate::parsers::test_helpers::{game_state_payload, test_timestamp, unity_entry};
 
     /// Helper: build a minimal `GameStateMessage` body with just one zone
     /// and no game objects (incremental update pattern).
+    /// Only used by tests that check zone contents (gated under not(lean)).
+    #[cfg(not(feature = "lean"))]
     fn minimal_game_state_message_body() -> String {
         format!(
             "[UnityCrossThreadLogger]greToClientEvent\n{}",
@@ -524,8 +568,9 @@ mod tests {
         }
     }
 
-    // -- Zone extraction ------------------------------------------------------
+    // -- Zone extraction (not compiled under `lean` — zones excluded from payload) --
 
+    #[cfg(not(feature = "lean"))]
     mod zone_extraction {
         use super::*;
 
@@ -709,8 +754,9 @@ mod tests {
         }
     }
 
-    // -- Game object extraction -----------------------------------------------
+    // -- Game object extraction (not compiled under `lean`) --------------------
 
+    #[cfg(not(feature = "lean"))]
     mod game_object_extraction {
         use super::*;
 
@@ -995,8 +1041,9 @@ mod tests {
         }
     }
 
-    // -- QueuedGameStateMessage -----------------------------------------------
+    // -- QueuedGameStateMessage (not compiled under `lean`) --------------------
 
+    #[cfg(not(feature = "lean"))]
     mod queued_game_state {
         use super::*;
 
@@ -1081,8 +1128,9 @@ mod tests {
         }
     }
 
-    // -- GameStateMessage edge cases ------------------------------------------
+    // -- GameStateMessage edge cases (not compiled under `lean`) --------------
 
+    #[cfg(not(feature = "lean"))]
     mod game_state_edge_cases {
         use super::*;
 
@@ -1336,10 +1384,11 @@ mod tests {
         }
     }
 
-    // -- Internal helpers ----------------------------------------------------
+    // -- Internal helpers (not compiled under `lean` — functions are gated) ----
 
+    #[cfg(not(feature = "lean"))]
     mod internal_helpers {
-        use super::*;
+        use super::super::{extract_single_game_object, extract_single_zone};
 
         #[test]
         fn test_extract_single_zone_valid() {
@@ -1488,8 +1537,9 @@ mod tests {
         }
     }
 
-    // -- Timer extraction ----------------------------------------------------
+    // -- Timer extraction (not compiled under `lean` — timers excluded) --------
 
+    #[cfg(not(feature = "lean"))]
     mod timer_extraction {
         use super::*;
 
@@ -1746,8 +1796,9 @@ mod tests {
         }
     }
 
-    // -- Ability chain fields (objectSourceGrpId, parentId) -------------------
+    // -- Ability chain fields (not compiled under `lean`) ---------------------
 
+    #[cfg(not(feature = "lean"))]
     #[test]
     fn test_game_object_ability_has_source_grp_id_and_parent_id() {
         let body = format!(
@@ -1788,6 +1839,7 @@ mod tests {
         assert_eq!(obj["parent_id"], 291);
     }
 
+    #[cfg(not(feature = "lean"))]
     #[test]
     fn test_game_object_card_omits_ability_chain_fields() {
         let body = format!(

--- a/src/parsers/gre/game_state.rs
+++ b/src/parsers/gre/game_state.rs
@@ -452,10 +452,6 @@ fn extract_single_game_object(obj: &serde_json::Value) -> Option<serde_json::Val
 mod tests {
     use super::super::test_fixtures::*;
     use super::super::try_parse;
-    // Under `lean`, zone/object/timer extraction functions are cfg'd away;
-    // the glob import would be empty and trigger an unused-import warning.
-    #[cfg(not(feature = "lean"))]
-    use super::*;
     use crate::parsers::test_helpers::{game_state_payload, test_timestamp, unity_entry};
 
     /// Helper: build a minimal `GameStateMessage` body with just one zone

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -56,10 +56,14 @@
 //! `GameObjectType_Ability` objects include `object_source_grp_id` and
 //! `parent_id` for resolving ability instances back to their source cards.
 
+// Annotations module is not compiled under `lean` — the lean game_state
+// payload omits annotations and persistent_annotations entirely.
+#[cfg(not(feature = "lean"))]
 mod annotations;
 mod connect_resp;
 mod game_result;
 mod game_state;
+#[cfg(not(feature = "lean"))]
 mod helpers;
 mod turn_info;
 

--- a/src/parsers/test_helpers.rs
+++ b/src/parsers/test_helpers.rs
@@ -105,6 +105,10 @@ define_payload_extractor!(draft_human_payload, DraftHuman);
 define_payload_extractor!(draft_complete_payload, DraftComplete);
 define_payload_extractor!(lifecycle_payload, EventLifecycle);
 define_payload_extractor!(rank_payload, Rank);
+// `deck_collection_payload` is only used by the matching sub-module of
+// deck_collection tests, which is gated under not(lean) because the lean
+// build omits the deck payload. Gate accordingly to silence dead_code.
+#[cfg(not(feature = "lean"))]
 define_payload_extractor!(deck_collection_payload, DeckCollection);
 define_payload_extractor!(inventory_payload, Inventory);
 define_payload_extractor!(match_connection_state_payload, MatchConnectionState);

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,28 +1,178 @@
 //! wasm-bindgen exports for the `wasm` cargo feature.
 //!
-//! This module exposes [`parse_whole_log_js`] — a thin wrapper around the
-//! native [`crate::parse_whole_log`] — via `wasm-bindgen` so that JS/TS
-//! consumers (e.g. a Parse Worker) can call `parseWholeLog(input)` and
-//! receive a live JS object graph instead of a JSON string.
+//! This module exposes two APIs:
+//!
+//! - [`parse_whole_log_js`] — a thin wrapper around [`crate::parse_whole_log`]
+//!   for callers that already have the entire log in memory.
+//! - [`StreamingParser`] — an incremental parser that accepts the log in
+//!   arbitrary chunks (`pushChunk`) and finalises with `finish`, keeping only
+//!   a small `tail` buffer in memory. Useful for very large logs or streaming
+//!   transports where holding the whole log is not desirable.
+//!
+//! Both APIs use the same serialiser configuration
+//! (`serialize_maps_as_objects(true)`) so their output is identical to the
+//! native `parse_whole_log` path.
 //!
 //! # Building
 //!
 //! ```bash
-//! wasm-pack build --target web --no-default-features --features wasm
+//! wasm-pack build --target bundler --no-default-features --features wasm
 //! ```
 //!
-//! The `wasm` feature implies `brace_depth_flush` so the artifact always has
-//! the same flush semantics as the desktop default build.
+//! The `wasm` feature implies `brace_depth_flush` (consistent flush semantics
+//! with the desktop default) and `lean` (omits `raw_bytes` + heavy payload
+//! fields to reduce WASM memory pressure).
 //!
 //! # Usage from JavaScript / TypeScript
 //!
 //! ```js
-//! import init, { parseWholeLog } from './pkg/manasight_parser.js';
+//! import init, { parseWholeLog, StreamingParser } from './pkg/manasight_parser.js';
 //! await init();
-//! const events = parseWholeLog(logText); // returns a JS array of GameEvent objects
+//!
+//! // Whole-log path:
+//! const events = parseWholeLog(logText);
+//!
+//! // Streaming path:
+//! const parser = new StreamingParser();
+//! const batch1 = parser.pushChunk(firstChunk);
+//! const batch2 = parser.pushChunk(secondChunk);
+//! const last   = parser.finish();
+//! parser.free(); // release WASM memory
 //! ```
 
+// wasm_bindgen is only available (and needed) under the `wasm` feature.
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Host-testable streaming core (not gated on `cfg(feature="wasm")`)
+// ---------------------------------------------------------------------------
+
+/// Incremental streaming parse core.
+///
+/// Accepts log text in arbitrary chunks and emits batches of [`crate::events::GameEvent`]
+/// values. The core is intentionally **not** gated on the `wasm` feature so
+/// that host-side tests (e.g. proptest parity checks) can drive it directly
+/// without WASM dependencies.
+///
+/// # Chunking contract
+///
+/// `push_chunk` replicates [`str::lines`] byte-for-byte:
+/// - Lines are separated by `'\n'`.
+/// - A trailing `'\r'` before each `'\n'` is stripped (CRLF → LF).
+/// - A final line not terminated by `'\n'` is held in `tail` and processed
+///   only by [`Self::finish`], matching the behaviour of
+///   `for line in input.lines()` followed by a `flush()` call.
+///
+/// Empty chunks are no-ops (tail is unchanged).
+pub struct StreamingParserCore {
+    buffer: crate::log::entry::LineBuffer,
+    router: crate::router::Router,
+    /// Incomplete final line from the last chunk (no trailing `'\n'` yet).
+    tail: String,
+}
+
+impl StreamingParserCore {
+    /// Creates a new, empty streaming core.
+    pub fn new() -> Self {
+        Self {
+            buffer: crate::log::entry::LineBuffer::new(),
+            router: crate::router::Router::new(),
+            tail: String::new(),
+        }
+    }
+
+    /// Processes a text chunk, returning any events completed by this chunk.
+    ///
+    /// The algorithm replicates `str::lines()` semantics:
+    ///
+    /// 1. Prepend any leftover `tail` from the previous call.
+    /// 2. Split on `'\n'`.
+    /// 3. For every piece **except the last**: strip a trailing `'\r'` (CRLF
+    ///    handling), feed to `LineBuffer::push_line`, collect events.
+    /// 4. Retain the last piece as the new `tail` (may be empty if the chunk
+    ///    ended with `'\n'`).
+    pub fn push_chunk(&mut self, text: &str) -> Vec<crate::events::GameEvent> {
+        if text.is_empty() {
+            return Vec::new();
+        }
+
+        // Build the full text to process by prepending any leftover tail.
+        let combined: std::borrow::Cow<str> = if self.tail.is_empty() {
+            std::borrow::Cow::Borrowed(text)
+        } else {
+            let mut s = std::mem::take(&mut self.tail);
+            s.push_str(text);
+            std::borrow::Cow::Owned(s)
+        };
+
+        let mut events = Vec::new();
+        let mut pieces = combined.split('\n');
+
+        // The split always produces at least one piece. We need to treat all
+        // pieces except the last as complete lines.
+        //
+        // `split` on `'\n'` yields:
+        //   "a\nb\n"  -> ["a", "b", ""]   (last is empty — chunk ended with \n)
+        //   "a\nb"    -> ["a", "b"]        (last is partial — no trailing \n)
+        //   ""        -> [""]              (empty — handled above, tail unchanged)
+        //
+        // We use `peekable` to detect the last piece without consuming ahead.
+        let mut peekable = pieces.by_ref().peekable();
+        while let Some(piece) = peekable.next() {
+            if peekable.peek().is_none() {
+                // Last piece — retain as tail (may be empty string).
+                piece.clone_into(&mut self.tail);
+            } else {
+                // Complete line — strip trailing `\r` to match `str::lines()` CRLF handling.
+                let line = piece.strip_suffix('\r').unwrap_or(piece);
+                for entry in self.buffer.push_line(line) {
+                    events.extend(self.router.route(&entry));
+                }
+            }
+        }
+
+        events
+    }
+
+    /// Finalises the stream, processing any remaining `tail` and flushing the
+    /// internal `LineBuffer`.
+    ///
+    /// Corresponds to the final `buffer.flush()` call in `parse_whole_log`:
+    /// drains any entry that was not followed by a new header.
+    ///
+    /// After `finish`, the core should be considered consumed. Calling
+    /// `push_chunk` or `finish` again will process against an empty state.
+    pub fn finish(&mut self) -> Vec<crate::events::GameEvent> {
+        let mut events = Vec::new();
+
+        // Process the leftover tail (the final line if not terminated by '\n').
+        if !self.tail.is_empty() {
+            let tail = std::mem::take(&mut self.tail);
+            let line = tail.strip_suffix('\r').unwrap_or(&tail);
+            for entry in self.buffer.push_line(line) {
+                events.extend(self.router.route(&entry));
+            }
+        }
+
+        // Flush any trailing entry that was not followed by a new header.
+        if let Some(entry) = self.buffer.flush() {
+            events.extend(self.router.route(&entry));
+        }
+
+        events
+    }
+}
+
+impl Default for StreamingParserCore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM-bindgen wrapper (gated on `cfg(feature="wasm")`)
+// ---------------------------------------------------------------------------
 
 /// Parses an entire MTG Arena `Player.log` string and returns a JS array of
 /// `GameEvent` objects.
@@ -34,7 +184,7 @@ use wasm_bindgen::prelude::*;
 /// All event payloads (and every nested dynamic object) are serialised as
 /// plain JS objects (`{}`), not `Map` instances, matching the shape produced
 /// by the native `serde_json` path.  Fields are reachable by normal property
-/// access (e.g. `event.GameState.payload.greToClientEvent`).
+/// access (e.g. `event.GameState.payload.type`).
 ///
 /// # Errors
 ///
@@ -47,6 +197,7 @@ use wasm_bindgen::prelude::*;
 /// (`parse_whole_log_js`) is distinct from the native `parse_whole_log` to
 /// avoid a symbol clash when the `wasm` feature is compiled on a non-wasm
 /// host (e.g. during `cargo clippy --all-features`).
+#[cfg(feature = "wasm")]
 #[wasm_bindgen(js_name = parseWholeLog)]
 pub fn parse_whole_log_js(input: &str) -> Result<JsValue, JsValue> {
     use serde::Serialize as _;
@@ -55,4 +206,93 @@ pub fn parse_whole_log_js(input: &str) -> Result<JsValue, JsValue> {
     events
         .serialize(&serializer)
         .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Incremental / streaming parser for MTG Arena log files, exposed as a
+/// `wasm-bindgen` export.
+///
+/// Accepts log text in arbitrary chunks via [`StreamingParser::push_chunk`]
+/// and finalises with [`StreamingParser::finish`].  Callers that have the
+/// whole log in memory should prefer [`parse_whole_log_js`] instead.
+///
+/// # Memory management
+///
+/// The handle allocates state in WASM linear memory. Callers **must** call
+/// `parser.free()` when done to release it. wasm-bindgen emits `free` as an
+/// ordinary export; usable via manual `WebAssembly.Instance` instantiation
+/// without a bundler.
+///
+/// # Example (JavaScript)
+///
+/// ```js
+/// const parser = new StreamingParser();
+/// let events = [];
+/// for (const chunk of logChunks) {
+///     events = events.concat(parser.pushChunk(chunk));
+/// }
+/// events = events.concat(parser.finish());
+/// parser.free();
+/// ```
+#[cfg(feature = "wasm")]
+#[wasm_bindgen]
+pub struct StreamingParser {
+    core: StreamingParserCore,
+}
+
+#[cfg(feature = "wasm")]
+impl Default for StreamingParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "wasm")]
+#[wasm_bindgen]
+impl StreamingParser {
+    /// Creates a new, empty `StreamingParser`.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            core: StreamingParserCore::new(),
+        }
+    }
+
+    /// Processes a text chunk and returns a JS array of `GameEvent` objects
+    /// completed by this chunk.
+    ///
+    /// The returned array may be empty if the chunk ends mid-line. Events are
+    /// emitted eagerly as soon as log entries are fully buffered.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `JsValue` error string if serialisation to JS fails.
+    #[wasm_bindgen(js_name = pushChunk)]
+    pub fn push_chunk(&mut self, text: &str) -> Result<JsValue, JsValue> {
+        use serde::Serialize as _;
+        let events = self.core.push_chunk(text);
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        events
+            .serialize(&serializer)
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Finalises the stream and returns a JS array of any remaining `GameEvent`
+    /// objects.
+    ///
+    /// Processes any partial final line held in the tail buffer and flushes the
+    /// internal `LineBuffer`, mirroring the trailing-entry flush in
+    /// `parse_whole_log`. Call `parser.free()` after this.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `JsValue` error string if serialisation to JS fails.
+    #[wasm_bindgen]
+    pub fn finish(&mut self) -> Result<JsValue, JsValue> {
+        use serde::Serialize as _;
+        let events = self.core.finish();
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        events
+            .serialize(&serializer)
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -10,8 +10,11 @@
 //!   transports where holding the whole log is not desirable.
 //!
 //! Both APIs use the same serialiser configuration
-//! (`serialize_maps_as_objects(true)`) so their output is identical to the
-//! native `parse_whole_log` path.
+//! (`serialize_maps_as_objects(true)`), so the serialiser output shape is
+//! identical to the native `parse_whole_log` path. However, the `wasm` build
+//! enables `lean`, which omits `raw_bytes` and heavy payload fields
+//! (annotations, timers, zones, `game_objects`, `raw_start_hook`, decks), so the
+//! wasm output is a lean subset of the full native output — not byte-identical.
 //!
 //! # Building
 //!
@@ -65,6 +68,13 @@ use wasm_bindgen::prelude::*;
 ///   `for line in input.lines()` followed by a `flush()` call.
 ///
 /// Empty chunks are no-ops (tail is unchanged).
+///
+/// # Stability
+///
+/// This type is `pub` only so that host-side tests can drive it without WASM
+/// dependencies. It is **not** part of the stable public API — breaking
+/// changes may occur without a semver bump.
+#[doc(hidden)]
 pub struct StreamingParserCore {
     buffer: crate::log::entry::LineBuffer,
     router: crate::router::Router,
@@ -147,10 +157,14 @@ impl StreamingParserCore {
         let mut events = Vec::new();
 
         // Process the leftover tail (the final line if not terminated by '\n').
+        //
+        // Do NOT strip a lone trailing '\r' here. `str::lines()` only removes
+        // '\r' as part of '\r\n'; the last element returned for a final line
+        // without a trailing '\n' retains any lone '\r'. Stripping it here would
+        // diverge from `parse_whole_log`'s `input.lines()` last element.
         if !self.tail.is_empty() {
             let tail = std::mem::take(&mut self.tail);
-            let line = tail.strip_suffix('\r').unwrap_or(&tail);
-            for entry in self.buffer.push_line(line) {
+            for entry in self.buffer.push_line(&tail) {
                 events.extend(self.router.route(&entry));
             }
         }

--- a/tests/game_over_annotations_integration.rs
+++ b/tests/game_over_annotations_integration.rs
@@ -7,16 +7,25 @@
 //! [`Router`] surface — the same code path a real `Player.log` line would
 //! take — and asserts the two-event sequence + annotation contents.
 
+// All items below are used only by the `not(lean)` test.
+#[cfg(not(feature = "lean"))]
 use manasight_parser::events::GameEvent;
+#[cfg(not(feature = "lean"))]
 use manasight_parser::log::entry::{EntryHeader, LogEntry};
+#[cfg(not(feature = "lean"))]
 use manasight_parser::router::Router;
 
 /// Sanitized fixture: a `[UnityCrossThreadLogger]greToClientEvent` entry
 /// whose `GameStateMessage` carries `GameStage_GameOver` plus the lethal
 /// combat damage (`AnnotationType_DamageDealt` x2, `ModifiedLife`,
 /// `LossOfGame`). Mirrors the real-game capture cited in the issue.
+#[cfg(not(feature = "lean"))]
 const FIXTURE: &str = include_str!("fixtures/game_over_with_damage_annotations.txt");
 
+/// Under the `lean` feature, annotations are excluded from the `GameState`
+/// payload — this test cannot verify annotation contents. It is compiled only
+/// for the non-lean build where the full payload is present.
+#[cfg(not(feature = "lean"))]
 #[test]
 fn test_game_over_with_damage_annotations_emits_game_state_then_game_result() {
     let entry = LogEntry {

--- a/tests/parse_whole_log_integration.rs
+++ b/tests/parse_whole_log_integration.rs
@@ -1,8 +1,14 @@
-//! Integration tests for [`manasight_parser::parse_whole_log`].
+//! Integration tests for [`manasight_parser::parse_whole_log`] and
+//! [`manasight_parser::wasm::StreamingParserCore`].
 //!
 //! Verifies that the sync entry point produces the same events as the
 //! entry-by-entry [`Router`] path, including trailing entries not followed
 //! by a header.
+//!
+//! Also verifies that [`StreamingParserCore`] (the host-testable streaming
+//! core) yields event-for-event equality with `parse_whole_log` across
+//! deterministic chunk sizes, CRLF inputs, mid-line splits, and random
+//! chunk sizes (via `proptest`).
 
 use manasight_parser::log::entry::LineBuffer;
 use manasight_parser::router::Router;
@@ -285,4 +291,213 @@ fn test_parse_whole_log_frame_prefixed_produces_same_game_events_as_unprefixed()
         events_prefixed, events_unprefixed,
         "frame-prefixed log must produce a byte-identical GameEvent stream to the unprefixed original",
     );
+}
+
+// ---------------------------------------------------------------------------
+// StreamingParserCore parity tests (#254)
+// ---------------------------------------------------------------------------
+
+/// Feeds `input` through a fresh [`StreamingParserCore`] in chunks of `chunk_size`
+/// bytes (clamped to valid UTF-8 boundaries by splitting on char boundaries),
+/// then finalises with `finish()`. Returns all collected events.
+///
+/// `chunk_size == 0` is treated as "whole input in one chunk".
+fn parse_via_streaming_core(input: &str, chunk_size: usize) -> Vec<GameEvent> {
+    use manasight_parser::wasm::StreamingParserCore;
+
+    let mut core = StreamingParserCore::new();
+    let mut events = Vec::new();
+
+    if chunk_size == 0 || chunk_size >= input.len() {
+        events.extend(core.push_chunk(input));
+    } else {
+        // Split on char boundaries so `&str` slices are always valid UTF-8.
+        let bytes = input.as_bytes();
+        let mut pos = 0;
+        while pos < bytes.len() {
+            let end = (pos + chunk_size).min(bytes.len());
+            // Advance end to the next char boundary.
+            let end = input
+                .char_indices()
+                .map(|(i, _)| i)
+                .find(|&i| i >= end)
+                .unwrap_or(bytes.len());
+            let chunk = &input[pos..end];
+            events.extend(core.push_chunk(chunk));
+            pos = end;
+        }
+    }
+
+    events.extend(core.finish());
+    events
+}
+
+// Multi-event fixture used across streaming parity tests.
+fn multi_event_input() -> String {
+    let gs_payload = serde_json::json!({
+        "greToClientEvent": {
+            "greToClientMessages": [{
+                "type": "GREMessageType_GameStateMessage",
+                "gameStateMessage": {
+                    "gameInfo": { "stage": "GameStage_Play" },
+                    "gameObjects": [],
+                    "zones": []
+                }
+            }]
+        }
+    });
+    format!(
+        "DETAILED LOGS: ENABLED\n\
+         [UnityCrossThreadLogger]authenticateResponse\n\
+         {{\"screenName\":\"TestPlayer\"}}\n\
+         [UnityCrossThreadLogger]2/25/2026 12:00:00 PM\n{gs_payload}\n\
+         [UnityCrossThreadLogger]2/25/2026 12:00:01 PM\nfiller\n"
+    )
+}
+
+#[test]
+fn test_streaming_core_chunk_size_1_parity() {
+    let input = multi_event_input();
+    let expected = parse_whole_log(&input);
+    let actual = parse_via_streaming_core(&input, 1);
+    assert_eq!(
+        expected, actual,
+        "chunk_size=1 must yield identical events to parse_whole_log"
+    );
+}
+
+#[test]
+fn test_streaming_core_chunk_size_2_parity() {
+    let input = multi_event_input();
+    let expected = parse_whole_log(&input);
+    let actual = parse_via_streaming_core(&input, 2);
+    assert_eq!(
+        expected, actual,
+        "chunk_size=2 must yield identical events to parse_whole_log"
+    );
+}
+
+#[test]
+fn test_streaming_core_chunk_size_3_parity() {
+    let input = multi_event_input();
+    let expected = parse_whole_log(&input);
+    let actual = parse_via_streaming_core(&input, 3);
+    assert_eq!(
+        expected, actual,
+        "chunk_size=3 must yield identical events to parse_whole_log"
+    );
+}
+
+#[test]
+fn test_streaming_core_chunk_size_7_parity() {
+    let input = multi_event_input();
+    let expected = parse_whole_log(&input);
+    let actual = parse_via_streaming_core(&input, 7);
+    assert_eq!(
+        expected, actual,
+        "chunk_size=7 must yield identical events to parse_whole_log"
+    );
+}
+
+#[test]
+fn test_streaming_core_chunk_size_64_parity() {
+    let input = multi_event_input();
+    let expected = parse_whole_log(&input);
+    let actual = parse_via_streaming_core(&input, 64);
+    assert_eq!(
+        expected, actual,
+        "chunk_size=64 must yield identical events to parse_whole_log"
+    );
+}
+
+#[test]
+fn test_streaming_core_whole_input_single_chunk_parity() {
+    let input = multi_event_input();
+    let expected = parse_whole_log(&input);
+    let actual = parse_via_streaming_core(&input, input.len());
+    assert_eq!(
+        expected, actual,
+        "whole-input single chunk must yield identical events to parse_whole_log"
+    );
+}
+
+/// CRLF line endings — `\r\n` sequences must be handled identically to `\n`.
+#[test]
+fn test_streaming_core_crlf_parity() {
+    // Build an input with CRLF line endings.
+    let lf_input = "DETAILED LOGS: ENABLED\n\
+                     [UnityCrossThreadLogger]authenticateResponse\n\
+                     {\"screenName\":\"CrlfPlayer\"}\n";
+    let crlf_input = lf_input.replace('\n', "\r\n");
+
+    let expected = parse_whole_log(lf_input);
+    // Feed the CRLF version through the streaming core in a single chunk.
+    let actual = parse_via_streaming_core(&crlf_input, crlf_input.len());
+    assert_eq!(
+        expected, actual,
+        "CRLF line endings must produce identical events to LF-only input"
+    );
+}
+
+/// Mid-line split: chunk boundary falls inside a line (not at `\n`).
+#[test]
+fn test_streaming_core_mid_line_split_parity() {
+    let input = "DETAILED LOGS: ENABLED\n\
+                  [UnityCrossThreadLogger]authenticateResponse\n\
+                  {\"screenName\":\"MidLinePlayer\"}\n";
+    let expected = parse_whole_log(input);
+    // chunk_size=5 is deliberately chosen to split mid-line.
+    let actual = parse_via_streaming_core(input, 5);
+    assert_eq!(
+        expected, actual,
+        "mid-line chunk split must not lose or duplicate events"
+    );
+}
+
+/// No trailing newline + empty-chunk case: final line ends without `\n`, and
+/// an additional empty chunk after finish must not cause panics or lost events.
+#[test]
+fn test_streaming_core_no_trailing_newline_parity() {
+    use manasight_parser::wasm::StreamingParserCore;
+
+    // The authenticateResponse entry has no trailing newline.
+    let input = "[UnityCrossThreadLogger]authenticateResponse\n\
+                  {\"screenName\":\"NoNewline\"}";
+    let expected = parse_whole_log(input);
+
+    let mut core = StreamingParserCore::new();
+    // Push the input, then push an empty chunk, then finish.
+    let mut events: Vec<GameEvent> = core.push_chunk(input);
+    let empty_batch = core.push_chunk(""); // must be a no-op
+    assert!(
+        empty_batch.is_empty(),
+        "empty chunk must return no events (tail unchanged)"
+    );
+    events.extend(core.finish());
+
+    assert_eq!(
+        expected, events,
+        "no-trailing-newline input must produce the same events via streaming core"
+    );
+}
+
+/// Proptest: random chunk sizes must produce identical events to `parse_whole_log`.
+#[cfg(not(target_arch = "wasm32"))]
+mod streaming_proptest {
+    use super::{multi_event_input, parse_via_streaming_core};
+    use manasight_parser::parse_whole_log;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_streaming_core_random_chunk_size_parity(chunk_size in 1usize..=512) {
+            let input = multi_event_input();
+            let expected = parse_whole_log(&input);
+            let actual = parse_via_streaming_core(&input, chunk_size);
+            prop_assert_eq!(
+                expected, actual,
+                "chunk_size={} must yield identical events", chunk_size
+            );
+        }
+    }
 }

--- a/tests/parse_whole_log_integration.rs
+++ b/tests/parse_whole_log_integration.rs
@@ -481,6 +481,72 @@ fn test_streaming_core_no_trailing_newline_parity() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// FIX 2 — Trailing-\r parity: finish() must match str::lines() byte-for-byte
+// ---------------------------------------------------------------------------
+
+/// `finish()` must NOT strip a lone trailing `\r` from the final partial line.
+///
+/// `str::lines()` only removes `'\r'` as part of `"\r\n"`. When the final line
+/// has no trailing `'\n'`, the `'\r'` (if any) is part of the line's content
+/// and must be passed through unchanged. Stripping it in `finish()` would
+/// diverge from `parse_whole_log`'s `input.lines()` last element.
+///
+/// These tests confirm byte-for-byte equality between `StreamingParserCore`
+/// and `parse_whole_log` for inputs where the trailing `\r` case matters.
+#[test]
+fn test_streaming_core_crlf_with_trailing_cr_parity() {
+    use manasight_parser::wasm::StreamingParserCore;
+
+    // "a\r\nb\r" — CRLF-terminated first line, then a line ending in bare \r.
+    // str::lines() splits this as ["a", "b\r"] (the \r\n pair is stripped,
+    // but the final \r is not).
+    let input = "DETAILED LOGS: ENABLED\r\n[UnityCrossThreadLogger]authenticateResponse\r\n{\"screenName\":\"TrailingCR\"}\r";
+    let expected = parse_whole_log(input);
+
+    let mut core = StreamingParserCore::new();
+    let mut events: Vec<GameEvent> = core.push_chunk(input);
+    events.extend(core.finish());
+
+    assert_eq!(
+        expected, events,
+        "input ending with bare \\r (not \\r\\n): streaming core must match parse_whole_log"
+    );
+}
+
+#[test]
+fn test_streaming_core_lone_trailing_cr_parity() {
+    use manasight_parser::wasm::StreamingParserCore;
+
+    // "foo\r" — a single line with a bare trailing \r and no \n.
+    // str::lines() returns ["foo\r"] (the \r is NOT stripped because there is no \n).
+    let input = "DETAILED LOGS: ENABLED\rfoo\r";
+    let expected = parse_whole_log(input);
+
+    let mut core = StreamingParserCore::new();
+    let mut events: Vec<GameEvent> = core.push_chunk(input);
+    events.extend(core.finish());
+
+    assert_eq!(
+        expected, events,
+        "input with only bare \\r (no \\n): streaming core must match parse_whole_log"
+    );
+}
+
+/// Regression guard: `"a\r\n"` (CRLF + trailing newline) must still produce
+/// the same events as `parse_whole_log` — the `push_chunk` CRLF stripping
+/// path must remain intact.
+#[test]
+fn test_streaming_core_crlf_trailing_newline_parity() {
+    let input = "DETAILED LOGS: ENABLED\r\n";
+    let expected = parse_whole_log(input);
+    let actual = parse_via_streaming_core(input, input.len());
+    assert_eq!(
+        expected, actual,
+        "CRLF input with trailing newline must match parse_whole_log"
+    );
+}
+
 /// Proptest: random chunk sizes must produce identical events to `parse_whole_log`.
 #[cfg(not(target_arch = "wasm32"))]
 mod streaming_proptest {

--- a/tests/smoke_parsers.rs
+++ b/tests/smoke_parsers.rs
@@ -16,24 +16,35 @@
 
 mod smoke_common;
 
+// Imports used only by the full (non-lean) smoke test are gated accordingly.
+#[cfg(not(feature = "lean"))]
 use std::collections::HashMap;
+#[cfg(not(feature = "lean"))]
 use std::fmt::Write as FmtWrite;
+#[cfg(not(feature = "lean"))]
 use std::path::Path;
 
+#[cfg(not(feature = "lean"))]
 use manasight_parser::events::GameEvent;
+#[cfg(not(feature = "lean"))]
 use manasight_parser::log::entry::LineBuffer;
+#[cfg(not(feature = "lean"))]
 use manasight_parser::log::timestamp::parse_log_timestamp;
 
+#[cfg(not(feature = "lean"))]
 use smoke_common::{
-    all_parsers, compare_against_baseline, event_type_name, is_bless_mode, read_baseline,
-    write_baseline, Baseline, BaselineFile, BaselineMeta, NamedParser, ParserStats,
+    all_parsers, compare_against_baseline, event_type_name, is_bless_mode, write_baseline,
+    Baseline, BaselineFile, BaselineMeta, NamedParser, ParserStats,
 };
+// `read_baseline` is also used by `test_baseline_meta_fields_present` (non-gated).
+use smoke_common::read_baseline;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 /// Aggregated report for a single log file.
+#[cfg(not(feature = "lean"))]
 struct FileReport {
     filename: String,
     /// Set when the file could not be read; remaining fields are zeroed.
@@ -69,6 +80,7 @@ struct FileReport {
     deck_collection_invariant_violations: usize,
 }
 
+#[cfg(not(feature = "lean"))]
 impl FileReport {
     /// Converts this report into a `BaselineFile` for ratchet comparison.
     fn to_baseline_file(&self) -> BaselineFile {
@@ -100,6 +112,7 @@ impl FileReport {
 // ---------------------------------------------------------------------------
 
 /// Tracks presence and counts of fields within `GameStateMessage` payloads.
+#[cfg(not(feature = "lean"))]
 #[derive(Default)]
 struct GsmFieldStats {
     turn_info_present: usize,
@@ -113,6 +126,7 @@ struct GsmFieldStats {
     diff_deleted_total: usize,
 }
 
+#[cfg(not(feature = "lean"))]
 impl GsmFieldStats {
     /// Updates stats from a single `GameState` event payload.
     fn track(&mut self, payload: &serde_json::Value) {
@@ -169,12 +183,14 @@ impl GsmFieldStats {
 // ---------------------------------------------------------------------------
 
 /// Tracks corpus-derived payload invariants for `DeckCollection` events.
+#[cfg(not(feature = "lean"))]
 #[derive(Default)]
 struct DeckCollectionStats {
     events: usize,
     invariant_violations: usize,
 }
 
+#[cfg(not(feature = "lean"))]
 impl DeckCollectionStats {
     /// Updates stats from a single `DeckCollection` event payload.
     fn track(&mut self, payload: &serde_json::Value) {
@@ -250,6 +266,7 @@ impl DeckCollectionStats {
 /// the remaining text as a timestamp. If the full text doesn't parse
 /// (e.g. timestamp followed by event content on the same line), tries
 /// progressively shorter prefixes.
+#[cfg(not(feature = "lean"))]
 fn try_extract_timestamp(body: &str) -> Option<chrono::DateTime<chrono::Utc>> {
     let first_line = body.lines().next()?;
     let content = match first_line.find(']') {
@@ -290,6 +307,7 @@ fn try_extract_timestamp(body: &str) -> Option<chrono::DateTime<chrono::Utc>> {
 /// `<== StartHook` responses contain both `InventoryInfo` and `Decks`/`DeckSummaries`,
 /// so the `inventory` and `collection` parsers legitimately claim the same
 /// entry -- each extracting different data from the shared response.
+#[cfg(not(feature = "lean"))]
 fn is_known_overlap(claimants: &[&str]) -> bool {
     claimants
         .iter()
@@ -301,6 +319,7 @@ fn is_known_overlap(claimants: &[&str]) -> bool {
 // ---------------------------------------------------------------------------
 
 /// Creates an error `FileReport` when a file cannot be read.
+#[cfg(not(feature = "lean"))]
 fn error_report(filename: String, parsers: &[NamedParser]) -> FileReport {
     FileReport {
         filename,
@@ -329,6 +348,7 @@ fn error_report(filename: String, parsers: &[NamedParser]) -> FileReport {
 }
 
 /// Processes a single log file through all parsers and returns a report.
+#[cfg(not(feature = "lean"))]
 fn process_file(path: &Path, parsers: &[NamedParser]) -> FileReport {
     let filename = path
         .file_name()
@@ -436,6 +456,7 @@ fn process_file(path: &Path, parsers: &[NamedParser]) -> FileReport {
     }
 }
 
+#[cfg(not(feature = "lean"))]
 fn write_deck_collection_report(out: &mut String, report: &FileReport) {
     let _ = writeln!(out, "  DeckCollection payloads:");
     let _ = writeln!(
@@ -450,6 +471,7 @@ fn write_deck_collection_report(out: &mut String, report: &FileReport) {
     );
 }
 
+#[cfg(not(feature = "lean"))]
 fn write_event_type_breakdown(out: &mut String, report: &FileReport) {
     let _ = writeln!(out, "  Event type breakdown:");
     let mut sorted_types: Vec<(&&'static str, &usize)> = report.event_type_counts.iter().collect();
@@ -468,6 +490,7 @@ fn write_event_type_breakdown(out: &mut String, report: &FileReport) {
 // ---------------------------------------------------------------------------
 
 /// Formats all file reports into a human-readable summary.
+#[cfg(not(feature = "lean"))]
 fn format_report(reports: &[FileReport]) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "\n=== Smoke Test Report ===\n");
@@ -578,6 +601,7 @@ fn format_report(reports: &[FileReport]) -> String {
 
 /// Converts file reports into a map suitable for ratchet comparison
 /// or baseline generation.
+#[cfg(not(feature = "lean"))]
 fn reports_to_baseline_files(
     reports: &[FileReport],
 ) -> std::collections::BTreeMap<String, BaselineFile> {
@@ -592,11 +616,13 @@ fn reports_to_baseline_files(
 ///
 /// In CI, this is set to the release tag of the downloaded corpus (e.g.
 /// `manasight-corpus-v3`).  For local runs it falls back to `"local"`.
+#[cfg(not(feature = "lean"))]
 fn read_corpus_tag() -> String {
     std::env::var("CORPUS_TAG").unwrap_or_else(|_| "local".to_string())
 }
 
 /// Builds a full `Baseline` from actual results for bless mode.
+#[cfg(not(feature = "lean"))]
 fn build_baseline(actual: &std::collections::BTreeMap<String, BaselineFile>) -> Baseline {
     // Get current git commit hash for metadata, falling back gracefully.
     let commit = std::process::Command::new("git")
@@ -630,7 +656,12 @@ fn build_baseline(actual: &std::collections::BTreeMap<String, BaselineFile>) -> 
 // Test entry point
 // ---------------------------------------------------------------------------
 
+/// Corpus-fidelity smoke test. Skipped under `lean` because `lean` intentionally
+/// omits payload fields (DeckCollection `raw_start_hook`/`decks`, GameState
+/// annotations/timers/zones/game_objects) that these invariants assert. CI runs
+/// this test on default (non-lean) features only.
 #[test]
+#[cfg(not(feature = "lean"))]
 fn smoke_test_real_logs() {
     let Some(logs_dir) = smoke_common::logs_dir_or_skip("smoke_test_real_logs") else {
         return;

--- a/tests/wasm_smoke.rs
+++ b/tests/wasm_smoke.rs
@@ -9,11 +9,24 @@
 //! ```
 //!
 //! The test asserts that the wasm-bindgen wrapper [`parse_whole_log_js`]
-//! produces a JS object graph that round-trips back through
-//! `serde_wasm_bindgen::from_value` to the same `Vec<GameEvent>` that the
-//! native [`parse_whole_log`] returns on the same input — proving wasm output
+//! produces a JS object graph whose **serialised JSON** matches the
+//! `serde_json` serialisation of the same `Vec<GameEvent>` that the native
+//! [`parse_whole_log`] returns on the same input — proving wasm output
 //! == native output on identical input (AC-ING-3 parity, no name
 //! special-casing required here; redaction is upstream).
+//!
+//! ## Why serialised JSON and not struct equality?
+//!
+//! The `wasm` feature implies `lean`.  Under `lean`,
+//! `EventMetadata.raw_bytes` is `#[serde(skip_serializing)]`.  A round-trip
+//! through the wasm JS object (serialize → deserialize) therefore yields
+//! `raw_bytes = []` and recomputes `raw_bytes_hash` from empty bytes, making
+//! the deserialized struct unequal to the native in-memory struct.  Both
+//! serialised forms are correct: `raw_bytes` is absent and `raw_bytes_hash`
+//! holds the real hash (computed at parse time, not during round-trip).
+//! Comparing `serde_json` output of native events (where lean also skips
+//! `raw_bytes`) to the stringified wasm output avoids this lossiness while
+//! still verifying all semantically meaningful fields.
 
 #![cfg(all(target_arch = "wasm32", feature = "wasm"))]
 
@@ -33,6 +46,23 @@ use wasm_bindgen_test::wasm_bindgen_test;
 const FIXTURE: &str = include_str!("fixtures/gsm_with_turn_info.txt");
 
 /// Parses the corpus fixture through both code paths and asserts they agree.
+///
+/// Parity is verified by comparing the **serialised JSON structure** of both
+/// paths — specifically `serde_json::Value` representations:
+/// - Native: `serde_json::to_value(&native_events)` — under `lean`,
+///   `raw_bytes` is `skip_serializing`, so the value omits that field and
+///   retains the correct `raw_bytes_hash`.
+/// - Wasm: `serde_wasm_bindgen::from_value::<serde_json::Value>(js_value)` —
+///   converts the JsValue to a generic JSON value without going through
+///   `EventMetadata`'s custom `Deserialize`.  The JsValue was produced by the
+///   wasm serialiser (lean), so `raw_bytes` is absent and `raw_bytes_hash` is
+///   the correct hash.
+///
+/// A typed struct round-trip (`serde_wasm_bindgen::from_value::<Vec<GameEvent>>`)
+/// is intentionally avoided: the custom `Deserialize` for `EventMetadata`
+/// recomputes `raw_bytes_hash` from the (now-empty) `raw_bytes`, producing a
+/// hash mismatch against the native struct even though both serialised forms
+/// are identical.
 #[wasm_bindgen_test]
 fn test_parse_whole_log_js_parity_with_native() {
     // Use an inline input that produces real events so this test is non-vacuous.
@@ -48,17 +78,21 @@ fn test_parse_whole_log_js_parity_with_native() {
 
     let js_value = parse_whole_log_js(FIXTURE).expect("wasm wrapper must not fail");
 
-    let wasm_events: Vec<GameEvent> =
-        serde_wasm_bindgen::from_value(js_value).expect("round-trip deserialisation must succeed");
+    // Serialise native events to a generic JSON value.  Under `lean`,
+    // `raw_bytes` is `skip_serializing`, so the value is structurally
+    // identical to what the wasm serialiser emits.
+    let native_value: serde_json::Value = serde_json::to_value(&native_events)
+        .expect("native events must serialise to serde_json::Value without error");
+
+    // Deserialise the wasm JsValue to a generic JSON value — this bypasses
+    // `EventMetadata`'s custom `Deserialize` (which would recompute the hash
+    // from empty bytes) and instead gives us the raw serialised shape directly.
+    let wasm_value: serde_json::Value =
+        serde_wasm_bindgen::from_value(js_value).expect("wasm JsValue must convert to JSON value");
 
     assert_eq!(
-        native_events.len(),
-        wasm_events.len(),
-        "event count must match between native and wasm paths"
-    );
-    assert_eq!(
-        native_events, wasm_events,
-        "every event must be identical between native and wasm paths"
+        native_value, wasm_value,
+        "serialised JSON structure must be identical between native and wasm paths"
     );
 }
 

--- a/tests/wasm_smoke.rs
+++ b/tests/wasm_smoke.rs
@@ -8,6 +8,16 @@
 //! wasm-pack test --node -- --no-default-features --features wasm
 //! ```
 //!
+//! ## Note on `test_parse_whole_log_js_empty_input`
+//!
+//! That test uses a typed round-trip (`serde_wasm_bindgen::from_value::<Vec<GameEvent>>`)
+//! and must NOT be extended to non-empty input under lean. The custom
+//! `EventMetadata` `Deserialize` impl recomputes `raw_bytes_hash` from the
+//! (lean-omitted, therefore empty) `raw_bytes`, producing a hash mismatch
+//! against the native struct even though both serialised forms are identical.
+//! Empty input is safe because there are no events (and thus no metadata) to
+//! round-trip.
+//!
 //! The test asserts that the wasm-bindgen wrapper [`parse_whole_log_js`]
 //! produces a JS object graph whose **serialised JSON** matches the
 //! `serde_json` serialisation of the same `Vec<GameEvent>` that the native
@@ -31,7 +41,9 @@
 #![cfg(all(target_arch = "wasm32", feature = "wasm"))]
 
 use js_sys::Reflect;
-use manasight_parser::{parse_whole_log, wasm::parse_whole_log_js, GameEvent};
+use manasight_parser::{
+    parse_whole_log, wasm::parse_whole_log_js, wasm::StreamingParser, GameEvent,
+};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -97,6 +109,14 @@ fn test_parse_whole_log_js_parity_with_native() {
 }
 
 /// Sanity-check: empty input produces zero events on both paths.
+///
+/// **WARNING:** This test uses a typed round-trip (`serde_wasm_bindgen::from_value::<Vec<GameEvent>>`)
+/// and must NOT be extended to non-empty input under `lean`. The custom
+/// `EventMetadata` `Deserialize` impl recomputes `raw_bytes_hash` from the
+/// (lean-omitted, therefore empty) `raw_bytes`, producing a hash mismatch
+/// against the native struct even though both serialised forms are identical.
+/// Empty input is safe because there are no events — and thus no metadata —
+/// to round-trip through the typed deserializer.
 #[wasm_bindgen_test]
 fn test_parse_whole_log_js_empty_input() {
     let native_events: Vec<GameEvent> = parse_whole_log("");
@@ -179,6 +199,105 @@ fn test_parse_whole_log_js_payload_is_plain_object_not_map() {
     // Assert a known field from build_game_state_message_payload is reachable
     // by property access (not .get()). The extracted payload always has
     // `"type": "game_state_message"` — use that as the stable key.
+    let type_field = Reflect::get(&payload_js, &JsValue::from_str("type"))
+        .expect("Reflect::get(type) must not throw");
+    assert!(
+        !type_field.is_undefined(),
+        "payload.type must be reachable by property access on a plain object"
+    );
+    assert_eq!(
+        type_field,
+        JsValue::from_str("game_state_message"),
+        "payload.type must equal \"game_state_message\" for a GameStateMessage"
+    );
+}
+
+/// Regression test: `StreamingParser` event payloads must be plain JS objects,
+/// not `Map` instances.
+///
+/// Feeds FIXTURE through `StreamingParser::pushChunk` / `finish` end-to-end and
+/// inspects the raw JS output to confirm `serialize_maps_as_objects(true)` is
+/// honoured in both methods.
+///
+/// If `push_chunk` or `finish` in `src/wasm.rs` are reverted to bare
+/// `serde_wasm_bindgen::to_value(&events)`, the payload becomes a JS `Map` and
+/// this test fails — guarding against that regression just as
+/// `test_parse_whole_log_js_payload_is_plain_object_not_map` guards
+/// `parse_whole_log_js` (PR #244 precedent).
+#[wasm_bindgen_test]
+fn test_streaming_parser_payload_is_plain_object_not_map() {
+    // Guard: confirm parse_whole_log produces >=1 GameState event so the
+    // end-to-end JS inspection below is not vacuous.
+    let native_events = parse_whole_log(FIXTURE);
+    assert!(
+        !native_events.is_empty(),
+        "parse_whole_log(FIXTURE) must produce >=1 event before the \
+         StreamingParser JS inspection can be meaningful"
+    );
+
+    // Feed FIXTURE through StreamingParser in two chunks so both push_chunk
+    // and finish are exercised. Split at the midpoint (valid UTF-8 boundary
+    // because FIXTURE is ASCII).
+    let mid = FIXTURE.len() / 2;
+    let (first_half, second_half) = FIXTURE.split_at(mid);
+
+    let mut parser = StreamingParser::new();
+
+    let batch1 = parser
+        .push_chunk(first_half)
+        .expect("push_chunk (first half) must not fail");
+    let batch2 = parser
+        .push_chunk(second_half)
+        .expect("push_chunk (second half) must not fail");
+    let last = parser.finish().expect("finish must not fail");
+
+    // Collect all JS values; at least one batch must be non-empty so the
+    // plain-object check is not vacuous.
+    let js_arrays = [&batch1, &batch2, &last];
+
+    // Find the first non-empty array.
+    let first_event_batch = js_arrays
+        .iter()
+        .find(|arr| {
+            let len = Reflect::get(arr, &JsValue::from_str("length"))
+                .ok()
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            len > 0.0
+        })
+        .expect("at least one batch must contain events from FIXTURE");
+
+    // Get the first event from the batch via index "0".
+    let first_event = Reflect::get(first_event_batch, &JsValue::from_str("0"))
+        .expect("Reflect::get(\"0\") must not throw");
+    assert!(
+        !first_event.is_undefined(),
+        "first event batch must have an element at index 0"
+    );
+
+    // GameEvent is externally-tagged: `{ GameState: { metadata, payload } }`.
+    let game_state_inner = Reflect::get(&first_event, &JsValue::from_str("GameState"))
+        .expect("Reflect::get(GameState) must not throw");
+    assert!(
+        !game_state_inner.is_undefined(),
+        "first event must be a GameState variant (got something else)"
+    );
+
+    let payload_js = Reflect::get(&game_state_inner, &JsValue::from_str("payload"))
+        .expect("Reflect::get(payload) must not throw");
+    assert!(
+        !payload_js.is_undefined(),
+        "GameState event must have a payload field"
+    );
+
+    // Core assertion: payload must NOT be a JS Map.
+    assert!(
+        !payload_js.is_instance_of::<js_sys::Map>(),
+        "StreamingParser payload must be a plain object, not a JS Map \
+         (serialize_maps_as_objects regression in push_chunk/finish)"
+    );
+
+    // Confirm the payload is reachable by plain property access.
     let type_field = Reflect::get(&payload_js, &JsValue::from_str("type"))
         .expect("Reflect::get(type) must not throw");
     assert!(


### PR DESCRIPTION
## Summary

- Adds `StreamingParserCore` (always compiled, host-testable) and a `wasm-bindgen`-exported `StreamingParser` (wasm-gated) with `pushChunk` and `finish` methods for incremental log parsing from JS streaming sources.
- Adds `lean` Cargo feature that omits `raw_bytes` from `EventMetadata` serialization and drops heavy fields (`zones`, `game_objects`, `annotations`, `timers`) from `GameState` and deck correlation data from `DeckCollection` payloads; `wasm` feature now auto-enables `lean`.
- Adds `#[serde(default)]` on `EventMetadataWire.raw_bytes` so lean-serialized events (absent `raw_bytes`) round-trip deserialize cleanly.
- Extends `tests/parse_whole_log_integration.rs` with `StreamingParserCore` parity tests: chunk sizes 1/2/3/7/64/full, CRLF equivalence, mid-line splits, no-trailing-newline, and a proptest over random chunk sizes 1–512.
- Reconciles stale `--target web` comment to `--target bundler` in `Cargo.toml`.

Fixes manasight/manasight-parser#254

## Test plan

- [ ] `cargo test --all-features` passes (only pre-existing env failure `test_discover_log_file_returns_error_in_ci` on MTGA-installed Mac)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (no issues)
- [ ] `cargo clippy --all-targets --features lean -- -D warnings` passes
- [ ] `cargo clippy --all-targets --no-default-features --features wasm -- -D warnings` passes
- [ ] `cargo test --no-default-features --features lean,brace_depth_flush` passes (1029 tests)
- [ ] Streaming parity tests verify identical event output vs. `parse_whole_log` for all chunk sizes and CRLF variants
- [ ] Proptest exercises 100 random chunk sizes 1–512 for fuzz coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)