### PR TITLE
chore: bump to v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.1] - 2026-06-22
+
+### Added
+
+- **`StreamingParser`** (`wasm` feature) — an incremental parse API
+  (`pushChunk` / `finish`) so consumers can stream very large logs at bounded
+  memory instead of materializing the whole log at once. Backed by a
+  host-testable `StreamingParserCore`; feeding a log in arbitrary byte chunks
+  yields event-for-event equality with `parse_whole_log` (`pushChunk` replicates
+  `str::lines()` exactly, including CRLF and split-boundary handling)
+  ([#254], [#255]).
+- **`lean` Cargo feature** — omits `raw_bytes` from `EventMetadata` (retaining
+  `raw_bytes_hash` for server-side deduplication) and drops never-read payload
+  fields (GameState `annotations` / `game_objects` / `zones` / `timers` /
+  `persistent_annotations`, the `DeckCollection` deck lists, and the inner
+  payload of never-consumed event variants) to minimize WASM memory and
+  bandwidth. Automatically enabled by the `wasm` feature; the default/native
+  build is byte-identical ([#254], [#255]).
+
+### Changed
+
+- Documentation: reconciled the WASM build command to `wasm-pack build
+  --target bundler` and documented the `lean` payload omissions across the
+  module, parser, and `README` docs ([#254], [#255]).
+- Internal dependency and CI bumps: `wasm-bindgen-test` 0.3.63 → 0.3.75
+  ([#250]), `log` 0.4.32 → 0.4.33 ([#249]), `actions/checkout` 4 → 7 ([#247]),
+  and `rust-lang/crates-io-auth-action` 1.0.4 → 1.0.5.
+
+### Notes
+
+- This release is **additive and backward-compatible**. The default (non-`lean`)
+  serialized output is unchanged; `lean` field omission and the `StreamingParser`
+  API are opt-in via the `wasm`/`lean` features.
+
+[#247]: https://github.com/manasight/manasight-parser/pull/247
+[#249]: https://github.com/manasight/manasight-parser/pull/249
+[#250]: https://github.com/manasight/manasight-parser/pull/250
+[#254]: https://github.com/manasight/manasight-parser/issues/254
+[#255]: https://github.com/manasight/manasight-parser/pull/255
+
 ## [0.6.0] - 2026-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "manasight-parser"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump `manasight-parser` from **0.6.0 → 0.6.1** in preparation for crates.io publish
- **Patch** release (0.x additive-only): no breaking changes; the default/native build is byte-identical

## Changes since v0.6.0

**Added**
- `StreamingParser` (`wasm`) incremental parse API (`pushChunk`/`finish`) over a host-testable `StreamingParserCore` — event-for-event parity with `parse_whole_log` (#254, #255)
- `lean` Cargo feature — omits `raw_bytes` (keeps `raw_bytes_hash`) and never-read payload fields to minimize WASM memory/bandwidth; auto-enabled by `wasm`, default build byte-identical (#254, #255)

**Changed**
- Docs reconciled to `--target bundler` + documented lean omissions (#254, #255)
- Internal dep/CI bumps: `wasm-bindgen-test` (#250), `log` (#249), `actions/checkout` (#247), `crates-io-auth-action`

## Test plan

- [x] `cargo check` clean; `cargo fmt --all -- --check` clean
- [ ] CI green (clippy + tests + fmt + smoke)
- [ ] After merge: tag `v0.6.1` and trigger publish-crate workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)