### PR TITLE
Fix #257: surface truncation-resilient local seat via LocalSeat event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.2] - 2026-06-24
+
+### Added
+
+- **`GameEvent::LocalSeat`** — a new event that surfaces the local player's
+  seat from the wrapper `systemSeatIds` of a client-directed GRE message (a
+  singleton `[N]`). The local seat was previously recoverable only via
+  `connect_resp.system_seat_ids`; when the client summarizes a `ConnectResp`
+  (a game state exceeding its internal GameObject limit), no `connect_resp`
+  event is emitted for the match and that seat channel is lost — leaving a
+  match with an authoritative outcome unresolvable. The new event recovers the
+  seat from the surrounding GRE envelopes, which still carry it (valid
+  envelopes flank the `Truncation` marker). Payload: `{"system_seat_id": N}`.
+  Emitted (idempotently) per client-directed entry carrying a singleton
+  wrapper seat — the parser is stateless per entry, so consumers associate it
+  to a match via event ordering relative to `match_started` /
+  `match_completed`, exactly as they already do for the seatless
+  `connect_resp` channel. Existing event variants are unchanged.
+
+  This adds a variant to the lean output → consumers re-parse.
+
 ## [0.6.1] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "manasight-parser"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/smoke-baseline.json
+++ b/smoke-baseline.json
@@ -2,7 +2,7 @@
   "_meta": {
     "corpus_tag": "manasight-corpus-v35",
     "description": "Smoke test baseline -- per-file, per-parser event counts from Level 1 (parser-only) smoke tests.",
-    "generated_from_commit": "39fe7b1"
+    "generated_from_commit": "47ae0a0"
   },
   "files": {
     "session_2026-02-22_0000_ecl-premier-bg-elves.log": {
@@ -15,6 +15,7 @@
         "GameResult": 5,
         "GameState": 4384,
         "Inventory": 7,
+        "LocalSeat": 688,
         "MatchState": 10,
         "Rank": 7,
         "Session": 6
@@ -50,6 +51,7 @@
         "GameResult": 4,
         "GameState": 3480,
         "Inventory": 5,
+        "LocalSeat": 528,
         "MatchState": 8,
         "Rank": 5,
         "Session": 5
@@ -83,6 +85,7 @@
         "GameResult": 2,
         "GameState": 810,
         "Inventory": 3,
+        "LocalSeat": 147,
         "MatchState": 4,
         "Rank": 3,
         "Session": 3
@@ -116,6 +119,7 @@
         "GameResult": 1,
         "GameState": 674,
         "Inventory": 2,
+        "LocalSeat": 112,
         "MatchState": 2,
         "Rank": 2,
         "Session": 2
@@ -149,6 +153,7 @@
         "GameResult": 1,
         "GameState": 1657,
         "Inventory": 2,
+        "LocalSeat": 273,
         "MatchState": 2,
         "Rank": 2,
         "Session": 2
@@ -212,6 +217,7 @@
         "GameResult": 1,
         "GameState": 309,
         "Inventory": 3,
+        "LocalSeat": 95,
         "MatchState": 2,
         "Rank": 3,
         "Session": 2
@@ -246,6 +252,7 @@
         "GameResult": 1,
         "GameState": 1334,
         "Inventory": 3,
+        "LocalSeat": 211,
         "MatchState": 3,
         "Rank": 3,
         "Session": 2
@@ -279,6 +286,7 @@
         "GameResult": 2,
         "GameState": 1094,
         "Inventory": 2,
+        "LocalSeat": 210,
         "MatchState": 2,
         "Rank": 2,
         "Session": 2
@@ -291,7 +299,7 @@
         "draft_complete": 0,
         "draft_human": 0,
         "event_lifecycle": 2,
-        "gre": 670,
+        "gre": 671,
         "inventory": 2,
         "match_state": 2,
         "metadata": 1,
@@ -300,7 +308,7 @@
       },
       "timestamp_failures": 49,
       "total_entries": 1159,
-      "unclaimed": 72
+      "unclaimed": 71
     },
     "session_2026-03-15_1157_detailed_logs_disabled.log": {
       "double_claims": 0,
@@ -334,6 +342,7 @@
         "GameResult": 2,
         "GameState": 459,
         "Inventory": 3,
+        "LocalSeat": 117,
         "MatchState": 4,
         "Rank": 3,
         "Session": 3
@@ -367,6 +376,7 @@
         "GameResult": 2,
         "GameState": 671,
         "Inventory": 2,
+        "LocalSeat": 162,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -379,7 +389,7 @@
         "draft_complete": 0,
         "draft_human": 0,
         "event_lifecycle": 2,
-        "gre": 303,
+        "gre": 304,
         "inventory": 2,
         "match_state": 2,
         "metadata": 1,
@@ -388,7 +398,7 @@
       },
       "timestamp_failures": 50,
       "total_entries": 712,
-      "unclaimed": 73
+      "unclaimed": 72
     },
     "session_2026-03-22_0000_feedback-019d1311.log": {
       "double_claims": 0,
@@ -400,6 +410,7 @@
         "GameResult": 2,
         "GameState": 2214,
         "Inventory": 2,
+        "LocalSeat": 298,
         "MatchState": 4,
         "Rank": 2,
         "Session": 2
@@ -433,6 +444,7 @@
         "GameResult": 10,
         "GameState": 3726,
         "Inventory": 11,
+        "LocalSeat": 728,
         "MatchState": 20,
         "Rank": 11,
         "Session": 10
@@ -466,6 +478,7 @@
         "GameResult": 6,
         "GameState": 3784,
         "Inventory": 7,
+        "LocalSeat": 569,
         "MatchState": 12,
         "Rank": 7,
         "Session": 6
@@ -497,6 +510,7 @@
         "GameResult": 1,
         "GameState": 494,
         "Inventory": 2,
+        "LocalSeat": 165,
         "MatchState": 2,
         "Rank": 2,
         "Session": 2
@@ -530,6 +544,7 @@
         "GameResult": 2,
         "GameState": 1764,
         "Inventory": 2,
+        "LocalSeat": 192,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -563,6 +578,7 @@
         "GameResult": 1,
         "GameState": 89,
         "Inventory": 5,
+        "LocalSeat": 21,
         "MatchState": 5,
         "Rank": 5,
         "Session": 25
@@ -595,6 +611,7 @@
         "EventLifecycle": 2,
         "GameState": 165,
         "Inventory": 4,
+        "LocalSeat": 30,
         "MatchState": 2,
         "Rank": 4,
         "Session": 14
@@ -628,6 +645,7 @@
         "GameResult": 1,
         "GameState": 156,
         "Inventory": 5,
+        "LocalSeat": 30,
         "MatchState": 5,
         "Rank": 5,
         "Session": 26
@@ -660,6 +678,7 @@
         "EventLifecycle": 2,
         "GameState": 116,
         "Inventory": 2,
+        "LocalSeat": 18,
         "MatchState": 1,
         "Rank": 2,
         "Session": 4
@@ -693,6 +712,7 @@
         "GameResult": 1,
         "GameState": 1084,
         "Inventory": 3,
+        "LocalSeat": 187,
         "MatchState": 2,
         "Rank": 3,
         "Session": 12
@@ -725,6 +745,7 @@
         "EventLifecycle": 2,
         "GameState": 244,
         "Inventory": 4,
+        "LocalSeat": 27,
         "MatchState": 2,
         "Rank": 4,
         "Session": 14
@@ -758,6 +779,7 @@
         "GameResult": 2,
         "GameState": 883,
         "Inventory": 7,
+        "LocalSeat": 172,
         "MatchState": 8,
         "Rank": 7,
         "Session": 30
@@ -791,6 +813,7 @@
         "GameResult": 2,
         "GameState": 829,
         "Inventory": 4,
+        "LocalSeat": 200,
         "MatchState": 5,
         "Rank": 4,
         "Session": 8
@@ -824,6 +847,7 @@
         "GameResult": 3,
         "GameState": 413,
         "Inventory": 3,
+        "LocalSeat": 79,
         "MatchState": 4,
         "Rank": 3,
         "Session": 15
@@ -858,6 +882,7 @@
         "GameResult": 3,
         "GameState": 246,
         "Inventory": 4,
+        "LocalSeat": 37,
         "MatchState": 6,
         "Rank": 4,
         "Session": 4
@@ -890,6 +915,7 @@
         "GameResult": 1,
         "GameState": 33,
         "Inventory": 2,
+        "LocalSeat": 9,
         "MatchState": 2,
         "Rank": 2,
         "Session": 2
@@ -924,6 +950,7 @@
         "GameResult": 6,
         "GameState": 1812,
         "Inventory": 7,
+        "LocalSeat": 378,
         "MatchState": 12,
         "Rank": 7,
         "Session": 9
@@ -958,6 +985,7 @@
         "GameResult": 3,
         "GameState": 2002,
         "Inventory": 4,
+        "LocalSeat": 435,
         "MatchState": 6,
         "Rank": 4,
         "Session": 4
@@ -990,6 +1018,7 @@
         "GameResult": 2,
         "GameState": 1149,
         "Inventory": 3,
+        "LocalSeat": 251,
         "MatchState": 4,
         "Rank": 3,
         "Session": 2
@@ -1022,6 +1051,7 @@
         "GameResult": 1,
         "GameState": 599,
         "Inventory": 2,
+        "LocalSeat": 186,
         "MatchState": 2,
         "Rank": 2,
         "Session": 2
@@ -1054,6 +1084,7 @@
         "GameResult": 8,
         "GameState": 2236,
         "Inventory": 9,
+        "LocalSeat": 516,
         "MatchState": 16,
         "Rank": 9,
         "Session": 9
@@ -1086,6 +1117,7 @@
         "GameResult": 1,
         "GameState": 656,
         "Inventory": 2,
+        "LocalSeat": 174,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1120,6 +1152,7 @@
         "GameResult": 1,
         "GameState": 9,
         "Inventory": 3,
+        "LocalSeat": 5,
         "MatchState": 2,
         "Rank": 4,
         "Session": 2
@@ -1210,6 +1243,7 @@
         "GameResult": 2,
         "GameState": 1451,
         "Inventory": 3,
+        "LocalSeat": 252,
         "MatchState": 4,
         "Rank": 3,
         "Session": 2
@@ -1242,6 +1276,7 @@
         "GameResult": 3,
         "GameState": 653,
         "Inventory": 4,
+        "LocalSeat": 149,
         "MatchState": 6,
         "Rank": 4,
         "Session": 3
@@ -1274,6 +1309,7 @@
         "GameResult": 2,
         "GameState": 708,
         "Inventory": 3,
+        "LocalSeat": 161,
         "MatchState": 4,
         "Rank": 3,
         "Session": 2
@@ -1306,6 +1342,7 @@
         "GameResult": 2,
         "GameState": 578,
         "Inventory": 3,
+        "LocalSeat": 151,
         "MatchState": 4,
         "Rank": 3,
         "Session": 2
@@ -1338,6 +1375,7 @@
         "GameResult": 1,
         "GameState": 277,
         "Inventory": 2,
+        "LocalSeat": 65,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1370,6 +1408,7 @@
         "GameResult": 1,
         "GameState": 249,
         "Inventory": 2,
+        "LocalSeat": 62,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1402,6 +1441,7 @@
         "GameResult": 1,
         "GameState": 564,
         "Inventory": 2,
+        "LocalSeat": 154,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1436,6 +1476,7 @@
         "GameResult": 1,
         "GameState": 563,
         "Inventory": 2,
+        "LocalSeat": 79,
         "MatchState": 2,
         "Rank": 2,
         "Session": 2
@@ -1470,6 +1511,7 @@
         "GameResult": 1,
         "GameState": 306,
         "Inventory": 2,
+        "LocalSeat": 41,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1504,6 +1546,7 @@
         "GameResult": 1,
         "GameState": 769,
         "Inventory": 2,
+        "LocalSeat": 112,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1538,6 +1581,7 @@
         "GameResult": 1,
         "GameState": 578,
         "Inventory": 2,
+        "LocalSeat": 102,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1572,6 +1616,7 @@
         "GameResult": 1,
         "GameState": 548,
         "Inventory": 2,
+        "LocalSeat": 77,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1606,6 +1651,7 @@
         "GameResult": 1,
         "GameState": 549,
         "Inventory": 2,
+        "LocalSeat": 47,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1640,6 +1686,7 @@
         "GameResult": 1,
         "GameState": 411,
         "Inventory": 2,
+        "LocalSeat": 51,
         "MatchState": 2,
         "Rank": 2,
         "Session": 3
@@ -1674,6 +1721,7 @@
         "GameResult": 1,
         "GameState": 821,
         "Inventory": 2,
+        "LocalSeat": 68,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1708,6 +1756,7 @@
         "GameResult": 1,
         "GameState": 305,
         "Inventory": 2,
+        "LocalSeat": 51,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1742,6 +1791,7 @@
         "GameResult": 2,
         "GameState": 538,
         "Inventory": 2,
+        "LocalSeat": 90,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1754,7 +1804,7 @@
         "draft_complete": 0,
         "draft_human": 0,
         "event_lifecycle": 2,
-        "gre": 203,
+        "gre": 204,
         "inventory": 2,
         "match_state": 2,
         "metadata": 1,
@@ -1763,7 +1813,7 @@
       },
       "timestamp_failures": 44,
       "total_entries": 465,
-      "unclaimed": 66
+      "unclaimed": 65
     },
     "session_2026-06-17_2005_pioneer-play-bo3.log": {
       "double_claims": 0,
@@ -1776,6 +1826,7 @@
         "GameResult": 3,
         "GameState": 1602,
         "Inventory": 2,
+        "LocalSeat": 324,
         "MatchState": 2,
         "Rank": 2,
         "Session": 1
@@ -1788,7 +1839,7 @@
         "draft_complete": 0,
         "draft_human": 0,
         "event_lifecycle": 2,
-        "gre": 780,
+        "gre": 782,
         "inventory": 2,
         "match_state": 2,
         "metadata": 1,
@@ -1797,7 +1848,7 @@
       },
       "timestamp_failures": 52,
       "total_entries": 1536,
-      "unclaimed": 79
+      "unclaimed": 77
     }
   }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -859,9 +859,14 @@ define_event! {
     /// Surfaces the local seat from the wrapper `systemSeatIds` of a
     /// client-directed GRE message (a singleton `[N]`), independent of
     /// `ConnectResp` — which the client may summarize away (see
-    /// [`GameEvent::LocalSeat`]). Following the header-only convention used by
-    /// [`TruncationEvent`], `raw_bytes` is empty (the seat is derived, not a
-    /// distinct loggable body) and the payload carries `{"system_seat_id": N}`.
+    /// [`GameEvent::LocalSeat`]). The payload carries `{"system_seat_id": N}`.
+    ///
+    /// `raw_bytes` is empty (like [`TruncationEvent`], the payload is the whole
+    /// event). Unlike `TruncationEvent` — whose source body is irrecoverable —
+    /// this event *does* have a source GRE envelope, but the sibling
+    /// [`GameStateEvent`] / [`GameResultEvent`] parsed from the same entry
+    /// already carries that body's `raw_bytes`; the seat is a derived signal, so
+    /// re-fingerprinting the parent entry here would only duplicate it.
     LocalSeatEvent
 }
 
@@ -1022,6 +1027,7 @@ mod tests {
             GameEvent::WebSocketClosed(WebSocketClosedEvent::new(meta.clone(), payload.clone())),
             GameEvent::ConnectionError(ConnectionErrorEvent::new(meta.clone(), payload.clone())),
             GameEvent::Truncation(TruncationEvent::new(meta.clone(), payload.clone())),
+            GameEvent::LocalSeat(LocalSeatEvent::new(meta.clone(), payload.clone())),
         ]
     }
 
@@ -1270,6 +1276,7 @@ mod tests {
             PerformanceClass::InteractiveDispatch, // WebSocketClosed
             PerformanceClass::InteractiveDispatch, // ConnectionError
             PerformanceClass::InteractiveDispatch, // Truncation
+            PerformanceClass::InteractiveDispatch, // LocalSeat
         ];
 
         assert_eq!(
@@ -1391,6 +1398,7 @@ mod tests {
             1, // WebSocketClosed
             1, // ConnectionError
             1, // Truncation
+            1, // LocalSeat
         ];
         assert_eq!(events.len(), expected_numbers.len());
         for (event, expected_num) in events.iter().zip(expected_numbers.iter()) {

--- a/src/events.rs
+++ b/src/events.rs
@@ -135,6 +135,7 @@ macro_rules! delegate_to_inner {
             Self::WebSocketClosed(e) => e.$method(),
             Self::ConnectionError(e) => e.$method(),
             Self::Truncation(e) => e.$method(),
+            Self::LocalSeat(e) => e.$method(),
         }
     };
 }
@@ -283,6 +284,26 @@ pub enum GameEvent {
     /// `{"object_count": N, "annotation_count": M}`; timestamp lives in
     /// `EventMetadata`. Class 1 — interactive dispatch.
     Truncation(TruncationEvent),
+
+    /// Local player's seat, recovered from a client-directed GRE message.
+    ///
+    /// The local seat is normally surfaced via `connect_resp.system_seat_ids`,
+    /// but when the client summarizes a `ConnectResp` (game state exceeds its
+    /// internal `GameObject` limit) no `connect_resp` event is emitted for the
+    /// match and that seat channel is lost. Client-directed GRE messages
+    /// (`GameStateMessage`, `PromptReq`, `MulliganReq`, …) carry a wrapper
+    /// `systemSeatIds` array; a singleton `[N]` identifies the local player's
+    /// seat and survives summarization (valid GRE envelopes flank the
+    /// `Truncation` marker). This event surfaces that seat so consumers can
+    /// resolve the local player even with no `connect_resp`.
+    ///
+    /// Payload is `{"system_seat_id": N}`. Emitted (idempotently) for each
+    /// client-directed entry carrying a singleton wrapper seat — the parser is
+    /// stateless per entry, so consumers dedup by match using event ordering
+    /// relative to `match_started` / `match_completed`, exactly as they
+    /// already associate the seatless `connect_resp` channel.
+    /// Class 1 — interactive dispatch.
+    LocalSeat(LocalSeatEvent),
 }
 
 impl GameEvent {
@@ -302,7 +323,8 @@ impl GameEvent {
             | Self::TcpConnectionClose(_)
             | Self::WebSocketClosed(_)
             | Self::ConnectionError(_)
-            | Self::Truncation(_) => PerformanceClass::InteractiveDispatch,
+            | Self::Truncation(_)
+            | Self::LocalSeat(_) => PerformanceClass::InteractiveDispatch,
             Self::DraftBot(_)
             | Self::DraftHuman(_)
             | Self::DraftComplete(_)
@@ -828,6 +850,33 @@ impl TruncationEvent {
         self.payload()["annotation_count"]
             .as_u64()
             .and_then(|v| u32::try_from(v).ok())
+    }
+}
+
+define_event! {
+    /// Local player's seat, recovered from a client-directed GRE message.
+    ///
+    /// Surfaces the local seat from the wrapper `systemSeatIds` of a
+    /// client-directed GRE message (a singleton `[N]`), independent of
+    /// `ConnectResp` — which the client may summarize away (see
+    /// [`GameEvent::LocalSeat`]). Following the header-only convention used by
+    /// [`TruncationEvent`], `raw_bytes` is empty (the seat is derived, not a
+    /// distinct loggable body) and the payload carries `{"system_seat_id": N}`.
+    LocalSeatEvent
+}
+
+impl LocalSeatEvent {
+    /// Creates a local-seat event from a recovered system seat id.
+    pub fn new_local_seat(timestamp: Option<DateTime<Utc>>, system_seat_id: i64) -> Self {
+        let metadata = EventMetadata::new(timestamp, Vec::new());
+        let payload = serde_json::json!({ "system_seat_id": system_seat_id });
+        Self::new(metadata, payload)
+    }
+
+    /// Returns the recovered local system seat id, or `None` if the payload
+    /// was manually constructed without the field.
+    pub fn system_seat_id(&self) -> Option<i64> {
+        self.payload()["system_seat_id"].as_i64()
     }
 }
 
@@ -1739,6 +1788,32 @@ mod tests {
         let event = TruncationEvent::new_truncation(None, 51, 0);
         assert!(event.metadata().local_timestamp().is_none());
         assert_eq!(event.object_count(), Some(51));
+    }
+
+    // -- LocalSeatEvent --
+
+    #[test]
+    fn test_local_seat_event_payload_contains_seat() {
+        let event = LocalSeatEvent::new_local_seat(None, 1);
+        assert_eq!(event.payload()["system_seat_id"], 1);
+        assert_eq!(event.system_seat_id(), Some(1));
+    }
+
+    #[test]
+    fn test_local_seat_event_metadata_has_empty_raw_bytes() {
+        // Following the TruncationEvent precedent — the seat is derived, not a
+        // distinct loggable body, so raw_bytes adds no fingerprint value.
+        let event = LocalSeatEvent::new_local_seat(None, 2);
+        assert!(event.metadata().raw_bytes().is_empty());
+    }
+
+    #[test]
+    fn test_local_seat_event_is_interactive_dispatch() {
+        let event = GameEvent::LocalSeat(LocalSeatEvent::new_local_seat(None, 1));
+        assert_eq!(
+            event.performance_class(),
+            PerformanceClass::InteractiveDispatch
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,9 @@ pub use event_bus::Subscriber;
 pub use events::{
     ClientActionEvent, DeckCollectionEvent, DeckSubmissionEvent, DetailedLoggingStatusEvent,
     DraftBotEvent, DraftCompleteEvent, DraftHumanEvent, EventLifecycleEvent, EventMetadata,
-    GameEvent, GameResultEvent, GameStateEvent, InventoryEvent, LogFileRotatedEvent,
-    MatchStateEvent, PerformanceClass, RankEvent, SessionEvent, TruncationEvent,
+    GameEvent, GameResultEvent, GameStateEvent, InventoryEvent, LocalSeatEvent,
+    LogFileRotatedEvent, MatchStateEvent, PerformanceClass, RankEvent, SessionEvent,
+    TruncationEvent,
 };
 pub use sanitize::{scrub_raw_log, scrub_raw_log_with, ScrubOptions};
 #[cfg(feature = "tailer")]

--- a/src/parsers/gre/connect_resp.rs
+++ b/src/parsers/gre/connect_resp.rs
@@ -500,7 +500,10 @@ mod tests {
         /// `greToClientMessages` array carries `[ConnectResp,
         /// DieRollResultsResp, GameStateMessage]`. The parser must emit the
         /// `ConnectResp` event first, followed by the GSM in source-array
-        /// order; the unhandled `DieRollResultsResp` is dropped.
+        /// order; the unhandled `DieRollResultsResp` is dropped. No `LocalSeat`
+        /// event is produced: a `ConnectResp` is present, so its `connect_resp`
+        /// channel is the authoritative local-seat source and the sibling GSM's
+        /// wrapper seat is not second-guessed.
         #[test]
         fn test_try_parse_connect_resp_bundled_with_gsm_emits_two_events() {
             let body = connect_resp_with_bundled_gsm_body();

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -183,6 +183,24 @@ pub fn try_parse(
         events.extend(emit_gsm_events(msg, body, timestamp));
     }
 
+    // If no rich event (ConnectResp / GSM) was produced, fall back to a
+    // low-value noise-type marker (UIMessage, TimerStateMessage,
+    // SetSettingsResp). Claimed with a minimal payload so they don't inflate
+    // the unclaimed-entry residual. This is *pushed* (not early-returned) so
+    // the `LocalSeat` append below stays purely additive and can never preempt
+    // it — a seat-bearing sibling message must not delete this noise marker.
+    if events.is_empty() {
+        for &noise_type in NOISE_MESSAGE_TYPES {
+            if find_message_by_type(messages, noise_type).is_some() {
+                ::log::trace!("greToClientEvent: claimed noise type {noise_type}");
+                let payload = serde_json::json!({ "recognized_type": noise_type });
+                let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
+                events.push(GameEvent::GameState(GameStateEvent::new(metadata, payload)));
+                break;
+            }
+        }
+    }
+
     // Recover the local player's seat from the wrapper `systemSeatIds` of a
     // client-directed GRE message (a singleton `[N]`). This is the
     // summarization-resilient seat channel: when the client summarizes a
@@ -190,33 +208,21 @@ pub fn try_parse(
     // surrounding GRE envelopes still carry the wrapper seat. Stateless and
     // per-entry — emitted (idempotently) whenever a singleton wrapper seat is
     // observed, so consumers associate it to a match via event ordering, just
-    // as they do the seatless `connect_resp` channel. Appended after the GSM
-    // events to preserve their existing ordering guarantees.
+    // as they do the seatless `connect_resp` channel. Appended LAST so it is
+    // purely additive — it never preempts the ConnectResp/GSM or noise events
+    // above (which would otherwise drop their `GameState`).
     if let Some(seat) = find_local_seat(messages) {
         events.push(GameEvent::LocalSeat(LocalSeatEvent::new_local_seat(
             timestamp, seat,
         )));
     }
 
-    if !events.is_empty() {
-        return events;
+    if events.is_empty() {
+        // Unrecognized GRE message type — log and skip.
+        ::log::debug!("greToClientEvent: no recognized message type found");
     }
 
-    // Check for low-value noise types (UIMessage, TimerStateMessage,
-    // SetSettingsResp). Claimed with a minimal payload so they don't inflate
-    // the unclaimed-entry residual.
-    for &noise_type in NOISE_MESSAGE_TYPES {
-        if find_message_by_type(messages, noise_type).is_some() {
-            ::log::trace!("greToClientEvent: claimed noise type {noise_type}");
-            let payload = serde_json::json!({ "recognized_type": noise_type });
-            let metadata = EventMetadata::new(timestamp, body.as_bytes().to_vec());
-            return vec![GameEvent::GameState(GameStateEvent::new(metadata, payload))];
-        }
-    }
-
-    // Unrecognized GRE message type — log and skip.
-    ::log::debug!("greToClientEvent: no recognized message type found");
-    Vec::new()
+    events
 }
 
 /// Builds the [`GameEvent`]s produced by a `GameStateMessage` /
@@ -321,6 +327,15 @@ fn find_message_by_type<'a>(
 /// singleton seat. Multi-element wrappers (a message addressed to both seats)
 /// are ignored, again so the opponent's seat is never mistaken for the local
 /// one.
+///
+/// Low-value **noise** message types ([`NOISE_MESSAGE_TYPES`]: `UIMessage`,
+/// `TimerStateMessage`, `SetSettingsResp`) are skipped. They are not part of
+/// the seat signal scoped by #257 (`GameStateMessage` / `PromptReq` /
+/// `MulliganReq`) — a `UIMessage` in particular is an emote/hover notification,
+/// not game-state-bearing. Skipping them keeps the seat a game signal and,
+/// crucially, lets a noise-only entry fall through to the noise fallback in
+/// [`try_parse`] (which emits its `GameState { recognized_type }` marker)
+/// instead of being preempted by a `LocalSeat` early-return.
 fn find_local_seat(messages: &[serde_json::Value]) -> Option<i64> {
     // When a ConnectResp is present, the connect_resp channel is the
     // authoritative local-seat source — do not recover from a sibling wrapper.
@@ -328,6 +343,12 @@ fn find_local_seat(messages: &[serde_json::Value]) -> Option<i64> {
         return None;
     }
     messages.iter().find_map(|msg| {
+        // Skip noise types — the seat is a game signal, and skipping them lets a
+        // noise-only entry reach the noise GameState fallback in `try_parse`.
+        let msg_type = msg.get("type").and_then(serde_json::Value::as_str);
+        if matches!(msg_type, Some(t) if NOISE_MESSAGE_TYPES.contains(&t)) {
+            return None;
+        }
         let seats = msg
             .get("systemSeatIds")
             .and_then(serde_json::Value::as_array)?;
@@ -1182,6 +1203,54 @@ mod tests {
                 seat_pos > result_pos,
                 "LocalSeat must be appended after GameResult"
             );
+        }
+
+        #[test]
+        fn test_noise_only_entry_emits_noise_gamestate_not_local_seat() {
+            // Regression: a noise-only entry (UIMessage) carrying a singleton
+            // wrapper seat must NOT have its noise `GameState { recognized_type }`
+            // marker preempted by a LocalSeat early-return. The seat is not
+            // recovered from noise traffic (an emote concerns either player), so
+            // the entry falls through to the noise fallback exactly as before.
+            let body = gre_body(&serde_json::json!([{
+                "type": "GREMessageType_UIMessage",
+                "systemSeatIds": [1],
+                "msgId": 7,
+                "gameStateId": 3
+            }]));
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+
+            assert!(
+                !results.iter().any(|e| matches!(e, GameEvent::LocalSeat(_))),
+                "a noise-only UIMessage must not recover a local seat"
+            );
+            assert!(
+                results.iter().any(|e| matches!(e, GameEvent::GameState(_))
+                    && e.payload()["recognized_type"] == "GREMessageType_UIMessage"),
+                "the noise GameState marker must still be emitted"
+            );
+        }
+
+        #[test]
+        fn test_noise_plus_seat_bearing_sibling_keeps_noise_gamestate() {
+            // A noise message (UIMessage) bundled with a non-noise, non-GSM
+            // request that carries a singleton wrapper seat, and NO GSM. The
+            // seat is recovered from the request, but the noise `GameState`
+            // marker must NOT be preempted — both events are emitted.
+            let body = gre_body(&serde_json::json!([
+                { "type": "GREMessageType_UIMessage", "systemSeatIds": [1], "msgId": 5 },
+                { "type": "GREMessageType_ActionsAvailableReq", "systemSeatIds": [1], "msgId": 6 }
+            ]));
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+
+            assert!(
+                results.iter().any(|e| matches!(e, GameEvent::GameState(_))
+                    && e.payload()["recognized_type"] == "GREMessageType_UIMessage"),
+                "the noise GameState marker must survive a seat-bearing sibling"
+            );
+            assert_eq!(local_seat_id(&results), Some(1));
         }
     }
 }

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -70,7 +70,7 @@ mod turn_info;
 #[cfg(test)]
 mod test_fixtures;
 
-use crate::events::{EventMetadata, GameEvent, GameResultEvent, GameStateEvent};
+use crate::events::{EventMetadata, GameEvent, GameResultEvent, GameStateEvent, LocalSeatEvent};
 use crate::log::entry::LogEntry;
 use crate::parsers::api_common;
 
@@ -168,6 +168,21 @@ pub fn try_parse(
     // processing only the first silently discards the majority of updates.
     for msg in messages {
         events.extend(emit_gsm_events(msg, body, timestamp));
+    }
+
+    // Recover the local player's seat from the wrapper `systemSeatIds` of a
+    // client-directed GRE message (a singleton `[N]`). This is the
+    // summarization-resilient seat channel: when the client summarizes a
+    // `ConnectResp`, no `connect_resp` event is emitted for the match, but the
+    // surrounding GRE envelopes still carry the wrapper seat. Stateless and
+    // per-entry — emitted (idempotently) whenever a singleton wrapper seat is
+    // observed, so consumers associate it to a match via event ordering, just
+    // as they do the seatless `connect_resp` channel. Appended after the GSM
+    // events to preserve their existing ordering guarantees.
+    if let Some(seat) = find_local_seat(messages) {
+        events.push(GameEvent::LocalSeat(LocalSeatEvent::new_local_seat(
+            timestamp, seat,
+        )));
     }
 
     if !events.is_empty() {
@@ -274,6 +289,39 @@ fn find_message_by_type<'a>(
     messages
         .iter()
         .find(|msg| msg.get("type").and_then(serde_json::Value::as_str) == Some(msg_type))
+}
+
+/// Recovers the local player's seat from a client-directed GRE message.
+///
+/// Client-directed GRE messages carry a wrapper `systemSeatIds` array. A
+/// **singleton** `[N]` is addressed to a single seat — the local player's
+/// own seat (e.g. a `MulliganReq` / `PromptReq` directed at the local client,
+/// or a `GameStateMessage` delivered to it). A `ConnectResp`'s own
+/// `systemSeatIds` is excluded here because the existing `connect_resp`
+/// channel already surfaces it; this helper exists for the case where that
+/// channel is absent (summarized `ConnectResp`).
+///
+/// Returns the first singleton wrapper seat found across the entry's messages,
+/// or `None` if no client-directed singleton seat is present. Multi-element
+/// wrappers (e.g. a message addressed to both seats) are ignored so the
+/// opponent's seat is never mistaken for the local one.
+fn find_local_seat(messages: &[serde_json::Value]) -> Option<i64> {
+    messages
+        .iter()
+        .filter(|msg| {
+            // Skip ConnectResp — its seat is already surfaced via the
+            // dedicated `connect_resp` event.
+            msg.get("type").and_then(serde_json::Value::as_str) != Some(CONNECT_RESP_TYPE)
+        })
+        .find_map(|msg| {
+            let seats = msg
+                .get("systemSeatIds")
+                .and_then(serde_json::Value::as_array)?;
+            match seats.as_slice() {
+                [only] => only.as_i64(),
+                _ => None,
+            }
+        })
 }
 
 // ---------------------------------------------------------------------------
@@ -951,6 +999,105 @@ mod tests {
             for event in &results {
                 assert_eq!(event.metadata().timestamp(), ts);
             }
+        }
+    }
+
+    // -- LocalSeat recovery ---------------------------------------------------
+
+    mod local_seat {
+        use super::*;
+
+        /// Builds a GRE entry body wrapping the given messages array.
+        fn gre_body(messages: &serde_json::Value) -> String {
+            format!(
+                "[UnityCrossThreadLogger]greToClientEvent\n{}",
+                serde_json::json!({ "greToClientEvent": { "greToClientMessages": messages } })
+            )
+        }
+
+        /// Returns the `system_seat_id` of the single `LocalSeat` event in
+        /// `results`, asserting exactly one is present.
+        fn local_seat_id(results: &[GameEvent]) -> Option<i64> {
+            let local = results
+                .iter()
+                .find(|e| matches!(e, GameEvent::LocalSeat(_)))
+                .unwrap_or_else(|| unreachable!("expected exactly one LocalSeat event"));
+            let GameEvent::LocalSeat(ref ev) = local else {
+                unreachable!("filter guard");
+            };
+            ev.system_seat_id()
+        }
+
+        #[test]
+        fn test_local_seat_emitted_from_singleton_gsm_wrapper() {
+            // A GSM addressed to seat 1 (singleton wrapper) — no ConnectResp.
+            let body = gre_body(&serde_json::json!([{
+                "type": "GREMessageType_GameStateMessage",
+                "systemSeatIds": [1],
+                "msgId": 2,
+                "gameStateId": 1,
+                "gameStateMessage": { "type": "GameStateType_Diff", "prevGameStateId": 0 }
+            }]));
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(local_seat_id(&results), Some(1));
+        }
+
+        #[test]
+        fn test_local_seat_recovered_for_seat_two() {
+            // A MulliganReq alone is not a GSM, so the only event is the LocalSeat.
+            let body = gre_body(&serde_json::json!([{
+                "type": "GREMessageType_MulliganReq",
+                "systemSeatIds": [2],
+                "msgId": 3,
+                "gameStateId": 1
+            }]));
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert_eq!(local_seat_id(&results), Some(2));
+        }
+
+        #[test]
+        fn test_no_local_seat_from_multi_element_wrapper() {
+            // A message addressed to BOTH seats must not surface a local seat —
+            // the opponent's seat must never be mistaken for the local one.
+            let body = gre_body(&serde_json::json!([{
+                "type": "GREMessageType_PromptReq",
+                "systemSeatIds": [1, 2],
+                "msgId": 4,
+                "gameStateId": 1
+            }]));
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert!(
+                !results.iter().any(|e| matches!(e, GameEvent::LocalSeat(_))),
+                "multi-element wrapper systemSeatIds must not produce a LocalSeat"
+            );
+        }
+
+        #[test]
+        fn test_connect_resp_seat_does_not_double_emit_local_seat() {
+            // A ConnectResp's own systemSeatIds is surfaced via connect_resp;
+            // it must NOT also produce a LocalSeat (no double channel).
+            let body = gre_body(&serde_json::json!([{
+                "type": "GREMessageType_ConnectResp",
+                "systemSeatIds": [1],
+                "msgId": 1,
+                "gameStateId": 0,
+                "connectResp": { "deckMessage": { "deckCards": [1, 2, 3] } }
+            }]));
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+
+            assert!(
+                results.iter().any(|e| matches!(e, GameEvent::GameState(_))
+                    && e.payload()["type"] == "connect_resp"),
+                "connect_resp event must still be emitted"
+            );
+            assert!(
+                !results.iter().any(|e| matches!(e, GameEvent::LocalSeat(_))),
+                "ConnectResp seat must not also emit a LocalSeat event"
+            );
         }
     }
 }

--- a/src/parsers/gre/mod.rs
+++ b/src/parsers/gre/mod.rs
@@ -20,6 +20,14 @@
 //! `QueuedGameStateMessage` wraps a deferred game state update with the same
 //! structure.
 //!
+//! In addition to the per-message events above, an entry that carries a
+//! **singleton** wrapper `systemSeatIds` (`[N]`) on any client-directed
+//! message other than `ConnectResp` also emits a single
+//! [`GameEvent::LocalSeat`] recovering the local player's seat — see
+//! [`find_local_seat`]. This is a truncation-resilient seat channel: when the
+//! client summarizes a `ConnectResp`, no `connect_resp` event is emitted, but
+//! the surrounding GRE envelopes still carry the local seat.
+//!
 //! Most messages are Class 1 (Interactive Dispatch). The exception is when
 //! `gameInfo.stage` equals `GameStage_GameOver` with
 //! `matchState != MatchState_MatchComplete` — these are emitted as
@@ -124,6 +132,11 @@ const GAME_STAGE_GAME_OVER: &str = "GameStage_GameOver";
 /// single `greToClientMessages` array. This function iterates **all**
 /// matching messages and returns a `Vec<GameEvent>` — one event per
 /// message. `ConnectResp` and noise types remain single-event.
+///
+/// If any client-directed message (other than `ConnectResp`) carries a
+/// singleton wrapper `systemSeatIds` (`[N]`), a single
+/// [`GameEvent::LocalSeat`] is appended after the per-message events to
+/// surface the local player's seat — see [`find_local_seat`].
 ///
 /// Returns an empty `Vec` if the entry does not match.
 ///
@@ -293,35 +306,36 @@ fn find_message_by_type<'a>(
 
 /// Recovers the local player's seat from a client-directed GRE message.
 ///
-/// Client-directed GRE messages carry a wrapper `systemSeatIds` array. A
-/// **singleton** `[N]` is addressed to a single seat — the local player's
-/// own seat (e.g. a `MulliganReq` / `PromptReq` directed at the local client,
-/// or a `GameStateMessage` delivered to it). A `ConnectResp`'s own
-/// `systemSeatIds` is excluded here because the existing `connect_resp`
-/// channel already surfaces it; this helper exists for the case where that
-/// channel is absent (summarized `ConnectResp`).
+/// This helper exists **only** for the case the existing `connect_resp` seat
+/// channel is absent for an entry (a summarized / dropped `ConnectResp`). When
+/// a `ConnectResp` is present **anywhere** in the entry, its `systemSeatIds`
+/// already surfaces the local seat authoritatively via the `connect_resp`
+/// event, so this returns `None` — we never second-guess that channel from a
+/// sibling message (a bundled GSM's wrapper `systemSeatIds` may be addressed to
+/// the *opponent's* seat and must not be mistaken for the local one).
 ///
-/// Returns the first singleton wrapper seat found across the entry's messages,
-/// or `None` if no client-directed singleton seat is present. Multi-element
-/// wrappers (e.g. a message addressed to both seats) are ignored so the
-/// opponent's seat is never mistaken for the local one.
+/// Otherwise, client-directed GRE messages carry a wrapper `systemSeatIds`
+/// array; a **singleton** `[N]` is addressed to a single seat — the local
+/// player's own seat (e.g. a `MulliganReq` / `PromptReq` directed at the local
+/// client, or a `GameStateMessage` delivered to it). Returns the first such
+/// singleton seat. Multi-element wrappers (a message addressed to both seats)
+/// are ignored, again so the opponent's seat is never mistaken for the local
+/// one.
 fn find_local_seat(messages: &[serde_json::Value]) -> Option<i64> {
-    messages
-        .iter()
-        .filter(|msg| {
-            // Skip ConnectResp — its seat is already surfaced via the
-            // dedicated `connect_resp` event.
-            msg.get("type").and_then(serde_json::Value::as_str) != Some(CONNECT_RESP_TYPE)
-        })
-        .find_map(|msg| {
-            let seats = msg
-                .get("systemSeatIds")
-                .and_then(serde_json::Value::as_array)?;
-            match seats.as_slice() {
-                [only] => only.as_i64(),
-                _ => None,
-            }
-        })
+    // When a ConnectResp is present, the connect_resp channel is the
+    // authoritative local-seat source — do not recover from a sibling wrapper.
+    if find_message_by_type(messages, CONNECT_RESP_TYPE).is_some() {
+        return None;
+    }
+    messages.iter().find_map(|msg| {
+        let seats = msg
+            .get("systemSeatIds")
+            .and_then(serde_json::Value::as_array)?;
+        match seats.as_slice() {
+            [only] => only.as_i64(),
+            _ => None,
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1097,6 +1111,76 @@ mod tests {
             assert!(
                 !results.iter().any(|e| matches!(e, GameEvent::LocalSeat(_))),
                 "ConnectResp seat must not also emit a LocalSeat event"
+            );
+        }
+
+        #[test]
+        fn test_no_local_seat_when_connect_resp_bundled_with_singleton_gsm() {
+            // When a ConnectResp is present in the entry, its connect_resp
+            // channel is authoritative — a sibling GSM's singleton wrapper seat
+            // (which may be the OPPONENT's seat) must NOT produce a LocalSeat.
+            let body = gre_body(&serde_json::json!([
+                {
+                    "type": "GREMessageType_ConnectResp",
+                    "systemSeatIds": [1, 2],
+                    "msgId": 1,
+                    "gameStateId": 0,
+                    "connectResp": { "deckMessage": { "deckCards": [1, 2, 3] } }
+                },
+                {
+                    "type": "GREMessageType_GameStateMessage",
+                    "systemSeatIds": [2],
+                    "msgId": 2,
+                    "gameStateId": 1,
+                    "gameStateMessage": { "type": "GameStateType_Diff", "prevGameStateId": 0 }
+                }
+            ]));
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+            assert!(
+                !results.iter().any(|e| matches!(e, GameEvent::LocalSeat(_))),
+                "a bundled ConnectResp suppresses LocalSeat recovery from a sibling GSM"
+            );
+        }
+
+        #[test]
+        fn test_local_seat_appended_after_game_result_on_game_over_gsm() {
+            // A GameOver GSM carrying a singleton wrapper seat emits the
+            // GameResult first; the LocalSeat is appended after it (no
+            // ConnectResp present), preserving the GameState/GameResult
+            // ordering guarantee.
+            let body = gre_body(&serde_json::json!([{
+                "type": "GREMessageType_GameStateMessage",
+                "systemSeatIds": [1],
+                "msgId": 9,
+                "gameStateId": 5,
+                "gameStateMessage": {
+                    "type": "GameStateType_Full",
+                    "gameInfo": {
+                        "stage": "GameStage_GameOver",
+                        "matchState": "MatchState_GameComplete",
+                        "results": [{
+                            "scope": "MatchScope_Game",
+                            "result": "ResultType_WinLoss",
+                            "winningTeamId": 1
+                        }]
+                    }
+                }
+            }]));
+            let entry = unity_entry(&body);
+            let results = try_parse(&entry, Some(test_timestamp()));
+
+            let result_pos = results
+                .iter()
+                .position(|e| matches!(e, GameEvent::GameResult(_)));
+            let seat_pos = results
+                .iter()
+                .position(|e| matches!(e, GameEvent::LocalSeat(_)));
+            assert!(result_pos.is_some(), "expected a GameResult event");
+            assert!(seat_pos.is_some(), "expected a LocalSeat event");
+            assert!(
+                seat_pos > result_pos,
+                "LocalSeat must be appended after GameResult"
             );
         }
     }

--- a/tests/fixtures/seat_attribution_no_connect_resp.log
+++ b/tests/fixtures/seat_attribution_no_connect_resp.log
@@ -1,2 +1,4 @@
 [UnityCrossThreadLogger]1/1/2026 12:00:00 PM matchGameRoomStateChangedEvent
 {"matchGameRoomStateChangedEvent":{"gameRoomInfo":{"stateType":"MatchGameRoomStateType_Playing","gameRoomConfig":{"matchId":"test-match-no-connect","eventId":"Ladder","reservedPlayers":[{"userId":"user-alice","playerName":"Alice#11111","systemSeatId":1,"teamId":1},{"userId":"user-bob","playerName":"Bob#22222","systemSeatId":2,"teamId":2}]}}}}
+[UnityCrossThreadLogger]1/1/2026 12:00:01 PM
+{"greToClientEvent":{"greToClientMessages":[{"type":"GREMessageType_GameStateMessage","systemSeatIds":[1],"msgId":2,"gameStateId":1,"gameStateMessage":{"type":"GameStateType_Diff","prevGameStateId":0,"zones":[],"gameObjects":[]}}]}}

--- a/tests/seat_attribution_integration.rs
+++ b/tests/seat_attribution_integration.rs
@@ -194,6 +194,96 @@ fn test_graceful_degradation_no_connect_resp_no_panic() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 5: Truncation-resilient local seat — no ConnectResp
+// ---------------------------------------------------------------------------
+
+/// Verifies that when no `ConnectResp` is present (so the usual
+/// `connect_resp.system_seat_ids` seat channel is absent), the local player's
+/// seat is still recovered from a client-directed GSM's wrapper
+/// `systemSeatIds` and surfaced as a `GameEvent::LocalSeat`.
+///
+/// Uses the `no_connect_resp` fixture, which carries a `GameStateMessage`
+/// addressed to seat 1 (singleton wrapper) but no `ConnectResp`.
+#[test]
+fn test_local_seat_recovered_without_connect_resp() {
+    let events = parse_whole_log(FIXTURE_NO_CONNECT_RESP);
+
+    // No ConnectResp event — the only seat channel is the recovered LocalSeat.
+    let has_connect_resp = events
+        .iter()
+        .any(|e| matches!(e, GameEvent::GameState(_)) && e.payload()["type"] == "connect_resp");
+    assert!(
+        !has_connect_resp,
+        "fixture must not produce a connect_resp event"
+    );
+
+    let local_seat_event = events
+        .iter()
+        .find(|e| matches!(e, GameEvent::LocalSeat(_)))
+        .unwrap_or_else(|| {
+            unreachable!("expected a LocalSeat event recovered from the GSM wrapper seat")
+        });
+
+    assert_eq!(
+        local_seat_event.payload()["system_seat_id"],
+        1,
+        "recovered local seat must be 1 (the singleton wrapper systemSeatIds)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Truncation-resilient local seat — summarized ConnectResp
+// ---------------------------------------------------------------------------
+
+/// The exact production shape from the issue: a match whose `ConnectResp` was
+/// summarized away (emitted as a `Truncation` marker), so zero `connect_resp`
+/// events exist — yet a surrounding client-directed GSM still carries the
+/// wrapper seat. The local seat must still be surfaced via `LocalSeat`.
+#[test]
+fn test_local_seat_recovered_with_summarized_connect_resp() {
+    // A summarized-ConnectResp marker block flanked by a valid GSM that carries
+    // the wrapper `systemSeatIds: [1]`. Mirrors the real Player.log shape where
+    // Arena emits the marker in place of the over-limit message while
+    // surrounding GRE envelopes continue to log normally.
+    let log = "\
+[UnityCrossThreadLogger]5/13/2026 10:01:11 AM\n\
+{\"greToClientEvent\":{\"greToClientMessages\":[{\"type\":\"GREMessageType_GameStateMessage\",\"systemSeatIds\":[1],\"msgId\":2,\"gameStateId\":1,\"gameStateMessage\":{\"type\":\"GameStateType_Diff\",\"prevGameStateId\":0,\"zones\":[],\"gameObjects\":[]}}]}}\n\
+[UnityCrossThreadLogger]5/13/2026 10:01:12 AM: Match to <transaction>: GreToClientEvent\n\
+[Message summarized because one or more GameStateMessages exceeded the 50 GameObject or 50 Annotation limit.]\n\
+::: GameStateMessage\n\
+:: GameObject Count = 63\n\
+:: Annotation Count = 4\n\
+::: ConnectResp\n\
+[UnityCrossThreadLogger]5/13/2026 10:01:13 AM Next\n";
+
+    let events = parse_whole_log(log);
+
+    // The summarized block becomes a Truncation event (no seat), and there is
+    // no connect_resp event for the match.
+    let has_truncation = events.iter().any(|e| matches!(e, GameEvent::Truncation(_)));
+    assert!(
+        has_truncation,
+        "summarized block must emit a Truncation event"
+    );
+    let has_connect_resp = events
+        .iter()
+        .any(|e| matches!(e, GameEvent::GameState(_)) && e.payload()["type"] == "connect_resp");
+    assert!(
+        !has_connect_resp,
+        "a summarized ConnectResp must not produce a connect_resp event"
+    );
+
+    // The local seat is still recovered from the surrounding GSM wrapper seat.
+    let local_seat_event = events
+        .iter()
+        .find(|e| matches!(e, GameEvent::LocalSeat(_)))
+        .unwrap_or_else(|| {
+            unreachable!("expected a LocalSeat event despite the summarized ConnectResp")
+        });
+    assert_eq!(local_seat_event.payload()["system_seat_id"], 1);
+}
+
+// ---------------------------------------------------------------------------
 // Test 4: Scrub-path — keep_player_names: false
 // ---------------------------------------------------------------------------
 

--- a/tests/smoke_common/mod.rs
+++ b/tests/smoke_common/mod.rs
@@ -155,6 +155,7 @@ pub fn event_type_name(event: &GameEvent) -> &'static str {
         GameEvent::Inventory(_) => "Inventory",
         GameEvent::DeckSubmission(_) => "DeckSubmission",
         GameEvent::GameResult(_) => "GameResult",
+        GameEvent::LocalSeat(_) => "LocalSeat",
         GameEvent::LogFileRotated(_) => "LogFileRotated",
         GameEvent::DetailedLoggingStatus(_) => "DetailedLoggingStatus",
         // `GameEvent` is `#[non_exhaustive]`; this branch keeps the compiler


### PR DESCRIPTION
## Summary

The local player's seat is currently recoverable only from `connect_resp.system_seat_ids`. When the MTGA client **summarizes a `ConnectResp`** (a game state exceeding its internal `GameObject` limit), the parser emits the summarized block as a single seatless `Truncation` event and produces **zero `connect_resp` events** for the match — removing the only seat channel. A match with an authoritative outcome (e.g. a short `ResultReason_Timeout` carrying a `MatchScope_Match winning_team_id`) is then left unresolvable. This is a real, observed shape in production `Player.log` data.

This adds a new `GameEvent::LocalSeat` that recovers the seat from a **truncation-resilient** channel.

## Changes Made

- **`GameEvent::LocalSeat { system_seat_id }`** (`src/events.rs`) — a new externally-tagged event variant + `LocalSeatEvent` (constructor `new_local_seat`, accessor `system_seat_id`), following the header-only `TruncationEvent` convention (empty `raw_bytes`, payload `{"system_seat_id": N}`). Class 1 (interactive dispatch). Existing variants are unchanged.
- **Seat recovery** (`src/parsers/gre/mod.rs`) — `find_local_seat` reads the wrapper `systemSeatIds` of a client-directed GRE message; a **singleton** `[N]` identifies the local player's seat. This wrapper survives summarization (valid GRE envelopes flank the `Truncation` marker). A `ConnectResp`'s own seat is excluded (already surfaced via `connect_resp`), and multi-element wrappers (messages addressed to both seats) are ignored so the opponent's seat is never mistaken for the local one.
- The parse pipeline is stateless per entry (`Router::route` is `&self`; both `parse_whole_log` and the streaming core just concatenate per-entry events), so `LocalSeat` is emitted **idempotently** whenever a singleton wrapper seat is observed. Consumers associate it to a match via event ordering relative to `match_started` / `match_completed`, exactly as they already do for the seatless `connect_resp` channel.
- **Version bump** `0.6.1` → `0.6.2` (`Cargo.toml`) + `CHANGELOG.md` entry — a new variant in the lean output, so consumers re-parse.

## Design note

The issue originally proposed putting `local_seat` on `match_started` and emitting it once per match keyed by `gameInfo.matchID`. While implementing, two clauses turned out not to hold against the actual code + wire data (see the issue thread): (1) `match_started` is built from `matchGameRoomStateChangedEvent` and is emitted **before** any seat-bearing GSM, and (2) the parse pipeline is stateless per entry, so "once per match" would require new cross-entry state in the `&self` router — out of scope for surfacing a dropped field. The wrapper-seat-bearing GSMs also frequently lack `gameInfo.matchID` in the real Diff-GSM sample. This PR implements the agreed stateless shape: a discrete idempotent `LocalSeat { system_seat_id }` event. A stateful once-per-match match-tracking layer, if wanted, is a separate feature.

## Testing

- Unit tests (`src/events.rs`, `src/parsers/gre/mod.rs`): new event payload/metadata/class; `find_local_seat` recovers either seat from a singleton wrapper, rejects multi-element wrappers, and does not double-emit on `ConnectResp`.
- Integration tests (`tests/seat_attribution_integration.rs`): the seat is surfaced with **no `connect_resp`**, and with a **summarized `ConnectResp`** (a GSM carrying the wrapper seat flanking a `Truncation` marker) — the exact production shape.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --all-features` all clean. (One pre-existing, environment-dependent test, `log::discovery::tests::test_discover_log_file_returns_error_in_ci`, fails only on a dev machine with MTGA installed and passes in CI; it is unrelated to this change.)

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)