### PR TITLE
chore: bump to v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.3] - 2026-06-26
+
+### Fixed
+
+- **Scrubber: redact hardware fingerprints** previously left in sanitized
+  output. The Unity `SystemInfo` hardware block (`graphicsDeviceName`,
+  `graphicsDeviceVendor`, `graphicsDeviceVersion`, `deviceModel`,
+  `operatingSystem`, `processorType`) on both macOS and Windows, plus the macOS
+  Metal `GfxDevice` block, are now redacted. Found and verified against the
+  `manasight-corpus` real logs (20/55 files leaked GPU/hardware identifiers
+  before this change; 0 after) ([#259], [#260]).
+
 ## [0.6.2] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "manasight-parser"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump `manasight-parser` from **0.6.2 → 0.6.3** in preparation for crates.io publish
- **Patch** release: privacy/redaction bug fix with no public API delta

## Changes since v0.6.2

**Fixed**
- Scrubber redacts hardware fingerprints previously left in sanitized output: the Unity `SystemInfo` hardware block (`graphicsDeviceName`, `graphicsDeviceVendor`, `graphicsDeviceVersion`, `deviceModel`, `operatingSystem`, `processorType`) on macOS and Windows, plus the macOS Metal `GfxDevice` block. Verified against the `manasight-corpus` real logs (20/55 files leaked before; 0 after) — #260, Closes #259.

No `lib.rs` / `events.rs` changes; only `src/sanitize.rs` internals. Public API (`scrub_raw_log`, `scrub_raw_log_with`, `ScrubOptions`) signatures unchanged.

## Test plan

- [x] `cargo check` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 1070 passed (lone `test_discover_log_file_returns_error_in_ci` fails only on a dev machine with MTGA installed; green in CI)
- [ ] CI green (clippy + tests + fmt)
- [ ] After merge: tag `v0.6.3` and trigger publish-crate workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)