### PR TITLE
chore: finalize CHANGELOG for 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.7.0] - 2026-07-02
 
 ### Added
 


### PR DESCRIPTION
## Summary

The `0.7.0` release was tagged (`v0.7.0`) and GitHub-released, but its
changelog entry was left under `## [Unreleased]` and never converted to a
versioned section. This renames it to `## [0.7.0] - 2026-07-02`, matching
the tag and the repo convention (top section = latest released version).

Discovered while completing the interrupted 0.7.0 crates.io publish.

## Changes

- **Changed:** `## [Unreleased]` → `## [0.7.0] - 2026-07-02` in `CHANGELOG.md`

No content changes — the deck-identity events (#267) and `ScrubOptions`
`keep_deck_names` toggle (#268) that shipped in 0.7.0 are already described
in the section.

## Test plan

- [x] Docs-only change (CHANGELOG.md)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)