### PR TITLE
Fix #270: CRLF-terminated lines escape $-anchored scrub patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   without `..Default::default()`) no longer compiles and must add the new
   field, or switch to `..Default::default()`.
 
+### Fixed
+
+- **Scrubber: CRLF-terminated lines bypassing `$`-anchored scrub patterns.**
+  The pet-diagnostic deck-name line and the macOS Metal enumerated-device
+  hardware-fingerprint line anchored on a bare `\)$`; on `\r\n`-terminated
+  log lines (standard for Windows-written `Player.log` files) the `\r`
+  before the newline broke the match, leaving the field unscrubbed under
+  default options. Both patterns now capture-and-re-emit an optional
+  trailing `\r` so CRLF lines are scrubbed without normalizing the line
+  ending to LF-only. A repo-wide sweep confirmed these were the only two
+  `$`-anchored scrub patterns exposed to this issue.
+
 ## [0.6.3] - 2026-06-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   default options. Both patterns now capture-and-re-emit an optional
   trailing `\r` so CRLF lines are scrubbed without normalizing the line
   ending to LF-only. A repo-wide sweep confirmed these were the only two
-  `$`-anchored scrub patterns exposed to this issue.
+  `$`-anchored scrub patterns exposed to this issue. Verified against
+  the `manasight-corpus` real logs (41/55 files are CRLF-terminated;
+  198 pet-diagnostic deck-name lines leaked before this change; 0 after).
 
 ## [0.6.3] - 2026-06-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "manasight-parser"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -204,9 +204,15 @@ static SCRUB_PATTERNS: LazyLock<Vec<ScrubPattern>> = LazyLock::new(|| {
         // Deck names: Unity console pet-diagnostic line (plain text, not
         // JSON). Optional `[N] ` frame prefix appears in unstripped archive
         // logs. is_deck_name = true — skipped when keep_deck_names is set.
+        // The trailing `(\r?)$` captures an optional CR before the line
+        // terminator and re-emits it in the replacement, so CRLF-terminated
+        // lines (standard for Windows-written Player.log files) are scrubbed
+        // without their line ending being normalized to LF-only. The `regex`
+        // crate has no lookahead, so a bare `\r?` before `$` would consume
+        // the `\r` rather than preserve it.
         (
-            r"(?m)^(\[\d+\] )?Can't find pet for deck .+ \(([0-9a-fA-F]{8})([0-9a-fA-F-]{28})\)$",
-            "${1}Can't find pet for deck Deck-${2} (${2}${3})",
+            r"(?m)^(\[\d+\] )?Can't find pet for deck .+ \(([0-9a-fA-F]{8})([0-9a-fA-F-]{28})\)(\r?)$",
+            "${1}Can't find pet for deck Deck-${2} (${2}${3})${4}",
             false,
             true,
         ),
@@ -260,10 +266,13 @@ static SCRUB_PATTERNS: LazyLock<Vec<ScrubPattern>> = LazyLock::new(|| {
         // Hardware fingerprint: macOS Metal GPU — enumerated device line.
         // Format: "N: <gpu-model> (high power)" / "N: <gpu-model> (low power)".
         // Anchored on the Metal power suffix to avoid over-matching other
-        // "N: …" log lines (e.g. numbered list items in game output).
+        // "N: …" log lines (e.g. numbered list items in game output). The
+        // trailing `(\r?)$` preserves an optional CR before the line
+        // terminator (see the pet-diagnostic pattern above for why capture-
+        // and-re-emit is used instead of a bare `\r?`).
         (
-            r"(?m)^\s*\d+:\s+.+\((?:high|low) power\)$",
-            "<N>: <redacted>",
+            r"(?m)^\s*\d+:\s+.+\((?:high|low) power\)(\r?)$",
+            "<N>: <redacted>${1}",
             false,
             false,
         ),
@@ -921,6 +930,31 @@ mod tests {
     }
 
     #[test]
+    fn test_scrub_raw_log_macos_metal_enumerated_device_crlf_terminator_preserved() {
+        // Metal GfxDevice lines can also appear with \r\n endings (e.g. a
+        // macOS log relayed through a Windows-hosted collector). The `$`
+        // anchor must match past the `\r`, and the `\r` must survive in the
+        // output byte-for-byte.
+        let input = "0: Apple M1 Pro (high power)\r\n1: Apple M2 Ultra (low power)\r\n";
+        let result = scrub_raw_log(input);
+        assert_eq!(result, "<N>: <redacted>\r\n<N>: <redacted>\r\n");
+    }
+
+    #[test]
+    fn test_scrub_raw_log_mixed_lf_and_crlf_line_terminators_preserved_independently() {
+        // A log with mixed line endings (e.g. concatenated from different
+        // sources) must have each line's own terminator preserved
+        // independently -- scrubbing must not normalize CRLF to LF or vice
+        // versa on either matched line.
+        let input = "0: Apple M1 Pro (high power)\nCan't find pet for deck My Cool Deck (1a2b3c4d-5e6f-7890-abcd-ef1234567890)\r\n";
+        let result = scrub_raw_log(input);
+        assert_eq!(
+            result,
+            "<N>: <redacted>\nCan't find pet for deck Deck-1a2b3c4d (1a2b3c4d-5e6f-7890-abcd-ef1234567890)\r\n"
+        );
+    }
+
+    #[test]
     fn test_scrub_raw_log_macos_metal_numbered_line_not_matched_without_power_suffix() {
         // The enumerated-device pattern is anchored on "(high|low power)" to
         // avoid false-positives on other numbered-list log lines that happen to
@@ -1419,6 +1453,33 @@ mod tests {
     }
 
     #[test]
+    fn test_scrub_raw_log_deck_name_pet_diagnostic_line_crlf_redacted_terminator_preserved() {
+        // Windows-written Player.log files use \r\n line endings. The pet-
+        // diagnostic pattern's `$` anchor must match past the `\r`, and the
+        // `\r` must survive in the output byte-for-byte (not be normalized
+        // to LF-only).
+        let input = "Line 1\r\nCan't find pet for deck My Cool Deck (1a2b3c4d-5e6f-7890-abcd-ef1234567890)\r\nLine 3\r\n";
+        let result = scrub_raw_log(input);
+        assert_eq!(
+            result,
+            "Line 1\r\nCan't find pet for deck Deck-1a2b3c4d (1a2b3c4d-5e6f-7890-abcd-ef1234567890)\r\nLine 3\r\n"
+        );
+    }
+
+    #[test]
+    fn test_scrub_raw_log_deck_name_pet_diagnostic_line_crlf_with_keep_deck_names_true_passthrough()
+    {
+        let opts = ScrubOptions {
+            keep_player_names: false,
+            keep_deck_names: true,
+        };
+        let input =
+            "Can't find pet for deck My Cool Deck (1a2b3c4d-5e6f-7890-abcd-ef1234567890)\r\n";
+        let result = scrub_raw_log_with(input, &opts);
+        assert_eq!(result, input);
+    }
+
+    #[test]
     fn test_scrub_raw_log_with_keep_deck_names_true_preserves_names() {
         let opts = ScrubOptions {
             keep_player_names: false,
@@ -1688,10 +1749,12 @@ mod tests {
             ),
             // Deck names: Unity console "Can't find pet for deck" diagnostic
             // (plain text, not JSON). Captures the name-or-label token.
+            // Detection-only, so `\r?` before `$` is sufficient here (no
+            // capture-and-re-emit needed — this pattern never rewrites text).
             (
                 "deck Name (pet-diagnostic line)",
                 Regex::new(
-                    r"(?m)^(?:\[\d+\] )?Can't find pet for deck (.+) \([0-9a-fA-F]{8}[0-9a-fA-F-]{28}\)$",
+                    r"(?m)^(?:\[\d+\] )?Can't find pet for deck (.+) \([0-9a-fA-F]{8}[0-9a-fA-F-]{28}\)\r?$",
                 )
                 .unwrap_or_else(|_| unreachable!()),
                 is_deck_label,

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1467,8 +1467,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scrub_raw_log_deck_name_pet_diagnostic_line_crlf_with_keep_deck_names_true_passthrough()
-    {
+    fn test_scrub_raw_log_with_keep_deck_names_true_crlf_passthrough() {
         let opts = ScrubOptions {
             keep_player_names: false,
             keep_deck_names: true,


### PR DESCRIPTION
## Summary

Two `$`-anchored scrub patterns in the privacy scrubber failed to match on `\r\n`-terminated log lines (standard for Windows-written `Player.log` files), leaving the matched field unscrubbed under default options. Both are fixed with a capture-and-re-emit of the optional trailing `\r`, preserving the original line terminator byte-for-byte.

## Changes Made

- `src/sanitize.rs`: pet-diagnostic deck-name line pattern and macOS Metal enumerated-device hardware-fingerprint pattern both changed their end anchor from `\)$` to `\)(\r?)$` (a new capture group added to each replacement string). The crate's `regex` dependency has no lookahead, so a bare `\r?` before `$` would consume the `\r` and normalize the line ending to LF-only; capture-and-re-emit avoids that.
- `src/sanitize.rs` (`#[cfg(test)]`): the pet-diagnostic PII-detection helper regex changed `\)$` to `\)\r?$` (detection-only, no replacement/capture needed).
- `CHANGELOG.md`: `Fixed` entry added.
- `Cargo.toml` / `Cargo.lock`: version `0.7.0` -> `0.7.1` (patch).

### Audit: every `$`-anchored pattern in the scrubber

| Pattern (site) | End-anchored on `$`? | CRLF-exposed? | Action |
|---|---|---|---|
| Pet-diagnostic deck-name line (plain-text scrub pattern) | yes | yes | fixed: `(\r?)$` capture-and-re-emit |
| macOS Metal enumerated-device line (hardware-fingerprint scrub pattern) | yes | yes | fixed: `(\r?)$` capture-and-re-emit |
| Pet-diagnostic PII-detection helper (`#[cfg(test)]`, corpus guard) | yes | yes (detection-only) | fixed: `\r?$`, no capture needed |
| JSON deck-name carrier, escaped-context (`\"DeckId\"`/`\"Name\"` pair) | no | n/a | unaffected, unchanged |
| JSON deck-name carrier, plain-context (`"DeckId"`/`"Name"` pair) | no | n/a | unaffected, unchanged |
| `keep_player_names` — `screenName` field | no | n/a | unaffected, unchanged |
| `keep_player_names` — `playerName` field | no | n/a | unaffected, unchanged |
| All other scrub patterns (tokens, paths, session IDs, remaining hardware-fingerprint lines, email/IP) | no | n/a | unaffected, unchanged |
| Doc-comment mention of a `Deck-<8hex>` label shape | not a compiled regex (doc comment only) | n/a | unaffected, unchanged |

Confirms the two sites named in the issue are the complete set.

## Testing

- New tests (exact-equality assertions, including line terminator; synthetic deck names only):
  - CRLF pet-diagnostic line scrubbed under default options, `\r\n` preserved byte-for-byte, plus surrounding LF-agnostic lines.
  - CRLF pet-diagnostic line passthrough under `keep_deck_names: true`, unchanged including `\r\n`.
  - CRLF macOS Metal enumerated-device line(s) scrubbed, `\r\n` preserved.
  - Mixed LF/CRLF multi-line input: each line's terminator preserved independently.
  - Existing LF fixtures unmodified (regression guard).
- `cargo test sanitize --all-features`: 98 passed.
- `make precommit`: `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` both clean. `cargo test --all-features`: 1124 passed, 1 failed — the pre-existing `log::discovery::tests::test_discover_log_file_returns_error_in_ci`, which only fails on machines with a real local MTGA `Player.log` (asserts discovery *errors*, which holds only in CI); unrelated to this change and out of scope.
- Coverage estimate: this change touches ~4-6 covered LOC (regex string literal edits) fully backstopped by 4 new tests; estimated coverage delta ≈ +0.0x pp (arithmetic estimate only, no local tarpaulin run).
- Real-corpus verification (`SCRUBBER_CORPUS_DIR` guard test `test_corpus_scrub_no_pii_survives`, run against all 55 decompressed `manasight-corpus` logs):
  - Before (main's scrub patterns, with only the CRLF-aware detection helper applied so the guard can see the leak class): the guard test fails — CRLF-terminated pet-diagnostic lines survive scrubbing. Most corpus files are CRLF-terminated, so the class is well represented. (Exact before/after counts are recorded in the private tracker.)
  - After (this branch): **0 leaks** — guard test passes.
  - This matches the evidentiary bar set for prior scrub-pattern fixes (CHANGELOG 0.6.3: corpus-verified before/after counts). Counts only; no scrubbed values are reproduced here.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Surhez8GiEQfz4v7a5bnwy


