### PR TITLE
Fix #272: Linux Player.log discovery — probe all Steam roots, prefer freshest log

### DIFF
--- a/src/log/discovery.rs
+++ b/src/log/discovery.rs
@@ -21,6 +21,8 @@
 //! Detailed Logging") and poll periodically until the file appears.
 
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::time::SystemTime;
 
 // ---------------------------------------------------------------------------
 // LogPaths
@@ -122,41 +124,45 @@ fn resolve_base_dir() -> Result<PathBuf, DiscoveryError> {
 
 /// Resolves the platform base directory for MTGA logs on Linux.
 ///
-/// Tries candidates in order (Steam/Proton first, then Lutris) and returns
-/// the `.../LocalLow` base dir for the first candidate whose `Player.log`
-/// exists.  The Linux arm is existence-aware because the base directory
-/// must be discovered dynamically (Steam library can be on any disk).
+/// Probes every known Steam installation root plus the Lutris fallback, and
+/// returns the `.../LocalLow` base dir for the candidate whose `Player.log`
+/// has the most recent modification time. The Linux arm is existence- and
+/// freshness-aware because the base directory must be discovered
+/// dynamically (a Steam library can be on any disk, and a stale leftover
+/// log in one candidate must not shadow a live log in another).
 ///
 /// Returns [`DiscoveryError::LogFileMissing`] (not [`DiscoveryError::UnsupportedPlatform`])
 /// when no candidate contains a `Player.log`, matching the absent-file
 /// contract of the Windows/macOS arms.
 #[cfg(target_os = "linux")]
 fn resolve_base_dir() -> Result<PathBuf, DiscoveryError> {
-    use crate::log::steam::{steam_library_for_appid, MTGA_APP_ID};
+    use crate::log::steam::{steam_libraries_for_appid, MTGA_APP_ID};
 
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
         .ok_or(DiscoveryError::BaseDirNotFound)?;
 
-    let steam_lib = steam_library_for_appid(MTGA_APP_ID);
-    let candidates = linux_candidate_base_dirs(&home, steam_lib.as_deref());
+    let steam_libraries = steam_libraries_for_appid(MTGA_APP_ID);
+    let candidates = linux_candidate_base_dirs(&home, &steam_libraries);
 
     let mtga_tail = Path::new("Wizards Of The Coast")
         .join("MTGA")
         .join("Player.log");
 
-    for candidate in &candidates {
-        if candidate.join(&mtga_tail).exists() {
-            ::log::info!("Linux: discovered MTGA base dir: {}", candidate.display());
-            return Ok(candidate.clone());
-        }
+    if let Some((base_dir, modified)) = select_freshest_candidate(&candidates, &mtga_tail) {
+        ::log::info!(
+            "Linux: discovered MTGA base dir: {} (Player.log modified {modified:?})",
+            base_dir.display(),
+        );
+        return Ok(base_dir);
     }
 
-    // Nothing found: report the Lutris path (last candidate) as the missing
-    // path so callers can surface a useful "file not found" message.
-    // The Lutris candidate is always present in the list (linux_candidate_base_dirs
-    // always appends it), so last() is always Some; fall back to building the
-    // Lutris path directly if the vector were somehow empty.
+    // Nothing found: report the first Steam-derived candidate as the
+    // missing path if any Steam library was found (so the error points at
+    // a real, if empty, Steam install), otherwise the Lutris fallback
+    // (last candidate, always present — linux_candidate_base_dirs always
+    // appends it), preserving today's error surface when no Steam install
+    // exists at all.
     let lutris_locallow = home
         .join("Games")
         .join("magic-the-gathering-arena")
@@ -165,7 +171,12 @@ fn resolve_base_dir() -> Result<PathBuf, DiscoveryError> {
         .join("steamuser")
         .join("AppData")
         .join("LocalLow");
-    let missing_path = candidates.into_iter().last().map_or_else(
+    let missing_base = if steam_libraries.is_empty() {
+        candidates.last()
+    } else {
+        candidates.first()
+    };
+    let missing_path = missing_base.map_or_else(
         || lutris_locallow.join(&mtga_tail),
         |base| base.join(&mtga_tail),
     );
@@ -177,29 +188,32 @@ fn resolve_base_dir() -> Result<PathBuf, DiscoveryError> {
     Err(DiscoveryError::LogFileMissing { path: missing_path })
 }
 
-/// Returns the ordered `.../LocalLow` candidate base directories for Linux
-/// MTGA discovery (Steam/Proton first, Lutris second).
+/// Returns the `.../LocalLow` candidate base directories for Linux MTGA
+/// discovery: one candidate per discovered Steam library, plus the Lutris
+/// fallback prefix.
 ///
-/// This pure helper takes `home` and an optional `steam_lib` so it can be
-/// unit-tested with temp directories without mutating `$HOME`.
+/// This pure helper takes `home` and the already-discovered Steam
+/// libraries so it can be unit-tested with temp directories without
+/// mutating `$HOME`.
 #[cfg(target_os = "linux")]
-pub(crate) fn linux_candidate_base_dirs(home: &Path, steam_lib: Option<&Path>) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
+pub(crate) fn linux_candidate_base_dirs(home: &Path, steam_libraries: &[PathBuf]) -> Vec<PathBuf> {
+    use crate::log::steam::MTGA_APP_ID;
 
-    // Steam/Proton (primary)
-    if let Some(library) = steam_lib {
-        let locallow = library
-            .join("steamapps")
-            .join("compatdata")
-            .join("2141910")
-            .join("pfx")
-            .join("drive_c")
-            .join("users")
-            .join("steamuser")
-            .join("AppData")
-            .join("LocalLow");
-        candidates.push(locallow);
-    }
+    let mut candidates: Vec<PathBuf> = steam_libraries
+        .iter()
+        .map(|library| {
+            library
+                .join("steamapps")
+                .join("compatdata")
+                .join(MTGA_APP_ID.to_string())
+                .join("pfx")
+                .join("drive_c")
+                .join("users")
+                .join("steamuser")
+                .join("AppData")
+                .join("LocalLow")
+        })
+        .collect();
 
     // Lutris (fallback, UNVERIFIED)
     let lutris_locallow = home
@@ -213,6 +227,29 @@ pub(crate) fn linux_candidate_base_dirs(home: &Path, steam_lib: Option<&Path>) -
     candidates.push(lutris_locallow);
 
     candidates
+}
+
+/// Selects the candidate whose `Player.log` (at `candidate.join(mtga_tail)`)
+/// has the most recent modification time.
+///
+/// Returns the winning base dir and its `Player.log` modification time, or
+/// `None` if no candidate has an existing, readable `Player.log`. Pure with
+/// respect to global/env state (depends only on its arguments and
+/// filesystem metadata), so it is unit-testable with tempdir fixtures.
+#[cfg(target_os = "linux")]
+fn select_freshest_candidate(
+    candidates: &[PathBuf],
+    mtga_tail: &Path,
+) -> Option<(PathBuf, SystemTime)> {
+    candidates
+        .iter()
+        .filter_map(|candidate| {
+            let modified = std::fs::metadata(candidate.join(mtga_tail))
+                .and_then(|m| m.modified())
+                .ok()?;
+            Some((candidate.clone(), modified))
+        })
+        .max_by_key(|(_, modified)| *modified)
 }
 
 /// Returns [`DiscoveryError::UnsupportedPlatform`] on non-Windows/macOS/Linux targets.
@@ -519,7 +556,9 @@ mod tests {
     mod linux_discovery {
         use super::*;
         use crate::log::discovery::linux_candidate_base_dirs;
+        use crate::log::steam::MTGA_APP_ID;
         use std::fs;
+        use std::time::Duration;
 
         type TestResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -532,19 +571,29 @@ mod tests {
         }
 
         #[test]
-        fn test_linux_candidate_base_dirs_steam_first_lutris_second() {
+        fn test_linux_candidate_base_dirs_one_candidate_per_library_then_lutris_last() {
             let home = PathBuf::from("/home/testuser");
-            let steam_lib = PathBuf::from("/mnt/games/SteamLibrary");
-            let candidates = linux_candidate_base_dirs(&home, Some(&steam_lib));
+            let libraries = vec![
+                PathBuf::from("/mnt/games/SteamLibrary"),
+                PathBuf::from("/home/testuser/.local/share/Steam"),
+            ];
+            let candidates = linux_candidate_base_dirs(&home, &libraries);
 
-            assert_eq!(candidates.len(), 2);
-            // Steam candidate is first
+            assert_eq!(candidates.len(), 3);
+            // One candidate per library, in order, each under its own library.
+            assert!(candidates[0].starts_with(&libraries[0]));
             assert!(candidates[0]
                 .to_string_lossy()
                 .contains("steamapps/compatdata"));
-            assert!(candidates[0].to_string_lossy().contains("2141910"));
-            // Lutris candidate is second
+            assert!(candidates[0]
+                .to_string_lossy()
+                .contains(&MTGA_APP_ID.to_string()));
+            assert!(candidates[1].starts_with(&libraries[1]));
             assert!(candidates[1]
+                .to_string_lossy()
+                .contains(&MTGA_APP_ID.to_string()));
+            // Lutris fallback is always last.
+            assert!(candidates[2]
                 .to_string_lossy()
                 .contains("Games/magic-the-gathering-arena"));
         }
@@ -552,7 +601,7 @@ mod tests {
         #[test]
         fn test_linux_candidate_base_dirs_no_steam_only_lutris() {
             let home = PathBuf::from("/home/testuser");
-            let candidates = linux_candidate_base_dirs(&home, None);
+            let candidates = linux_candidate_base_dirs(&home, &[]);
 
             assert_eq!(candidates.len(), 1);
             assert!(candidates[0]
@@ -561,93 +610,66 @@ mod tests {
         }
 
         #[test]
-        fn test_linux_resolve_base_dir_steam_found() -> TestResult {
+        fn test_select_freshest_candidate_no_existing_logs_returns_none() -> TestResult {
             let tmp = tempfile::tempdir()?;
-            let steam_lib = tmp.path().join("SteamLibrary");
-            let locallow = steam_lib
-                .join("steamapps")
-                .join("compatdata")
-                .join("2141910")
-                .join("pfx")
-                .join("drive_c")
-                .join("users")
-                .join("steamuser")
-                .join("AppData")
-                .join("LocalLow");
-            let mtga_dir = locallow.join("Wizards Of The Coast").join("MTGA");
-            fs::create_dir_all(&mtga_dir)?;
-            fs::write(mtga_dir.join("Player.log"), "test")?;
-
-            let candidates = linux_candidate_base_dirs(tmp.path(), Some(&steam_lib));
+            let candidates = vec![tmp.path().join("a"), tmp.path().join("b")];
             let mtga_tail = Path::new("Wizards Of The Coast")
                 .join("MTGA")
                 .join("Player.log");
 
-            let found = candidates.iter().find(|c| c.join(&mtga_tail).exists());
-            assert!(found.is_some(), "Steam candidate should be found");
-            assert_eq!(found, Some(&locallow));
+            assert!(select_freshest_candidate(&candidates, &mtga_tail).is_none());
             Ok(())
         }
 
         #[test]
-        fn test_linux_resolve_base_dir_lutris_fallback() -> TestResult {
+        fn test_select_freshest_candidate_single_existing_log_is_selected() -> TestResult {
             let tmp = tempfile::tempdir()?;
-            // No steam lib; only Lutris
-            let lutris_locallow = tmp
-                .path()
-                .join("Games")
-                .join("magic-the-gathering-arena")
-                .join("drive_c")
-                .join("users")
-                .join("steamuser")
-                .join("AppData")
-                .join("LocalLow");
-            let mtga_dir = lutris_locallow.join("Wizards Of The Coast").join("MTGA");
-            fs::create_dir_all(&mtga_dir)?;
-            fs::write(mtga_dir.join("Player.log"), "test")?;
-
-            let candidates = linux_candidate_base_dirs(tmp.path(), None);
+            let only = tmp.path().join("only");
+            fs::create_dir_all(player_log_path(&only).parent().unwrap_or(&only))?;
+            fs::write(player_log_path(&only), "test")?;
+            let candidates = vec![only.clone()];
             let mtga_tail = Path::new("Wizards Of The Coast")
                 .join("MTGA")
                 .join("Player.log");
 
-            let found = candidates.iter().find(|c| c.join(&mtga_tail).exists());
-            assert!(found.is_some(), "Lutris candidate should be found");
-            assert_eq!(found, Some(&lutris_locallow));
+            match select_freshest_candidate(&candidates, &mtga_tail) {
+                Some((base_dir, _)) => assert_eq!(base_dir, only),
+                None => {
+                    return Err(
+                        "expected the only candidate with a Player.log to be selected".into(),
+                    )
+                }
+            }
             Ok(())
         }
 
         #[test]
-        fn test_linux_candidate_base_dirs_nothing_found_no_candidates_match() -> TestResult {
+        fn test_select_freshest_candidate_prefers_freshest_even_when_listed_first() -> TestResult {
+            // Regression coverage for the stale-fallback-shadowing bug: a
+            // candidate that is *listed first* but has a *stale* Player.log
+            // must lose to a later-listed candidate with a *fresher* one —
+            // selection is by mtime, not list order / first-exists.
             let tmp = tempfile::tempdir()?;
-            // No Player.log anywhere
-            let steam_lib = tmp.path().join("SteamLibrary");
-            let candidates = linux_candidate_base_dirs(tmp.path(), Some(&steam_lib));
+            let stale = tmp.path().join("stale-first");
+            let fresh = tmp.path().join("fresh-second");
             let mtga_tail = Path::new("Wizards Of The Coast")
                 .join("MTGA")
                 .join("Player.log");
 
-            let found = candidates.iter().find(|c| c.join(&mtga_tail).exists());
-            assert!(
-                found.is_none(),
-                "No candidate should match when files don't exist"
-            );
+            for base in [&stale, &fresh] {
+                let log_path = base.join(&mtga_tail);
+                fs::create_dir_all(log_path.parent().unwrap_or(base))?;
+            }
+            fs::write(stale.join(&mtga_tail), "old leftover log")?;
+            std::thread::sleep(Duration::from_millis(50));
+            fs::write(fresh.join(&mtga_tail), "live log")?;
+
+            let candidates = vec![stale.clone(), fresh.clone()];
+            match select_freshest_candidate(&candidates, &mtga_tail) {
+                Some((base_dir, _)) => assert_eq!(base_dir, fresh),
+                None => return Err("expected a candidate to be selected".into()),
+            }
             Ok(())
-        }
-
-        #[test]
-        fn test_linux_candidate_steam_path_contains_correct_appid() {
-            let home = PathBuf::from("/home/user");
-            let steam_lib = PathBuf::from("/home/user/.local/share/Steam");
-            let candidates = linux_candidate_base_dirs(&home, Some(&steam_lib));
-
-            assert!(!candidates.is_empty());
-            let steam_candidate = &candidates[0];
-            assert!(
-                steam_candidate.to_string_lossy().contains("2141910"),
-                "Steam candidate must use MTGA app id 2141910: {}",
-                steam_candidate.display()
-            );
         }
 
         #[test]

--- a/src/log/steam.rs
+++ b/src/log/steam.rs
@@ -1,10 +1,12 @@
 //! Steam library discovery helpers for Linux.
 //!
-//! Parses `~/.local/share/Steam/steamapps/libraryfolders.vdf` to find the
-//! Steam library that contains a given app ID, then returns the library root
-//! path.  This is required because Steam allows users to install games on
-//! any configured library disk — the default `~/.local/share/Steam` path is
-//! not guaranteed to contain a given title.
+//! Probes every known Steam installation root (native, the `~/.steam/root`
+//! and `~/.steam/steam` symlinks, Flatpak, and Snap), parsing each root's
+//! `steamapps/libraryfolders.vdf` to find the Steam library that contains a
+//! given app ID. This is required because Steam allows users to install
+//! games on any configured library disk — the default
+//! `~/.local/share/Steam` path is not guaranteed to contain a given title,
+//! and not every install uses that default root at all.
 //!
 //! The VDF format used by `libraryfolders.vdf` is a subset of Valve's
 //! `KeyValues` text format (VDF v1).  We use a hand-rolled line scanner rather
@@ -36,29 +38,85 @@
 //! }
 //! ```
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 /// MTGA's Steam App ID.
 pub(crate) const MTGA_APP_ID: u32 = 2_141_910;
 
-/// Locate the Steam library root that contains `appid`.
+/// Locate every Steam library that contains `appid`, probing all known
+/// Steam installation roots.
 ///
-/// Parses `~/.local/share/Steam/steamapps/libraryfolders.vdf` and returns the
-/// `path` value of the first library entry whose `apps` block contains the
-/// given `appid`.
-///
-/// Falls back to `~/.local/share/Steam` if:
-/// - the VDF file is missing / unreadable, **and**
-/// - `<default_steam>/steamapps/compatdata/<appid>` exists.
-///
-/// Returns `None` if neither the VDF nor the fallback resolve to a library
-/// that contains the app's `compatdata` directory.
-pub(crate) fn steam_library_for_appid(appid: u32) -> Option<PathBuf> {
-    let home = std::env::var_os("HOME").map(PathBuf::from)?;
-    let default_steam = home.join(".local").join("share").join("Steam");
-    let vdf_path = default_steam.join("steamapps").join("libraryfolders.vdf");
+/// Reads `$HOME` and delegates to [`steam_libraries_for_appid_in`]. Returns
+/// an empty `Vec` if `$HOME` is unset.
+pub(crate) fn steam_libraries_for_appid(appid: u32) -> Vec<PathBuf> {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return Vec::new();
+    };
+    steam_libraries_for_appid_in(&home, appid)
+}
 
-    // Try to parse the VDF and find the library that contains appid.
+/// Locate every Steam library that contains `appid`, given a home
+/// directory.
+///
+/// Probes, in order: `~/.steam/root`, `~/.steam/steam` (the two common
+/// Steam symlinks), `~/.local/share/Steam` (native default), the Flatpak
+/// install path, and the Snap install path. Roots that don't exist and
+/// roots that canonicalize to a real directory already probed via another
+/// alias are skipped. For each remaining root, parses
+/// `steamapps/libraryfolders.vdf` for a library containing `appid`, falling
+/// back to the root itself if `steamapps/compatdata/<appid>` exists there
+/// directly.
+///
+/// Takes `home` as a parameter (rather than reading `$HOME` directly) so it
+/// can be exercised with tempdir fixtures — VDF parsing and compatdata
+/// fallback included — without mutating the process environment.
+pub(crate) fn steam_libraries_for_appid_in(home: &Path, appid: u32) -> Vec<PathBuf> {
+    let mut seen_roots: HashSet<PathBuf> = HashSet::new();
+    let mut libraries = Vec::new();
+
+    for root in candidate_steam_roots(home) {
+        let Ok(canonical_root) = std::fs::canonicalize(&root) else {
+            continue; // doesn't exist, or a broken symlink
+        };
+        if !seen_roots.insert(canonical_root.clone()) {
+            continue; // already probed this real directory via another root alias
+        }
+        if let Some(library) = library_for_root(&canonical_root, appid) {
+            libraries.push(library);
+        }
+    }
+
+    libraries
+}
+
+/// Ordered set of Steam installation roots to probe, before existence
+/// checking and canonical-path deduplication.
+fn candidate_steam_roots(home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join(".steam").join("root"),
+        home.join(".steam").join("steam"),
+        home.join(".local").join("share").join("Steam"),
+        home.join(".var")
+            .join("app")
+            .join("com.valvesoftware.Steam")
+            .join(".local")
+            .join("share")
+            .join("Steam"),
+        home.join("snap")
+            .join("steam")
+            .join("common")
+            .join(".local")
+            .join("share")
+            .join("Steam"),
+    ]
+}
+
+/// Checks a single, already-canonicalized Steam root for a library
+/// containing `appid`: first via `libraryfolders.vdf`, then via the
+/// `compatdata` fallback (the root itself, if present).
+fn library_for_root(root: &Path, appid: u32) -> Option<PathBuf> {
+    let vdf_path = root.join("steamapps").join("libraryfolders.vdf");
     if vdf_path.exists() {
         if let Ok(contents) = std::fs::read_to_string(&vdf_path) {
             if let Some(library) = parse_library_for_appid(&contents, appid) {
@@ -67,10 +125,9 @@ pub(crate) fn steam_library_for_appid(appid: u32) -> Option<PathBuf> {
         }
     }
 
-    // Fallback: check the default Steam library directly.
-    let compat = default_compat_path(&default_steam, appid);
-    if compat.exists() {
-        return Some(default_steam);
+    // Fallback: check this root directly.
+    if default_compat_path(root, appid).exists() {
+        return Some(root.to_path_buf());
     }
 
     None
@@ -320,5 +377,166 @@ mod tests {
         // A line with only one quoted token (e.g., `"apps"`) has no value.
         let result = extract_key_value(r#"        "apps""#);
         assert_eq!(result, None);
+    }
+
+    // -- Root probing: steam_libraries_for_appid_in (tempdir fixtures) --
+
+    mod root_probing {
+        use super::*;
+        use std::fs;
+        use std::os::unix::fs::symlink;
+
+        type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+        /// Write a minimal single-library `libraryfolders.vdf` under
+        /// `root/steamapps/` mapping `appid` to `library_path`.
+        fn write_vdf(root: &Path, appid: u32, library_path: &Path) -> std::io::Result<()> {
+            let steamapps = root.join("steamapps");
+            fs::create_dir_all(&steamapps)?;
+            let path = library_path.display();
+            let vdf = format!(
+                r#"
+"libraryfolders"
+{{
+    "0"
+    {{
+        "path"    "{path}"
+        "apps"
+        {{
+            "{appid}"    "12345678"
+        }}
+    }}
+}}
+"#
+            );
+            fs::write(steamapps.join("libraryfolders.vdf"), vdf)
+        }
+
+        /// Create `root/steamapps/compatdata/<appid>/` so the compatdata
+        /// fallback matches `root` directly (no VDF involved).
+        fn write_compatdata(root: &Path, appid: u32) -> std::io::Result<()> {
+            fs::create_dir_all(
+                root.join("steamapps")
+                    .join("compatdata")
+                    .join(appid.to_string()),
+            )
+        }
+
+        #[test]
+        fn test_steam_libraries_for_appid_in_default_root_vdf_match_returns_library() -> TestResult
+        {
+            let home = tempfile::tempdir()?;
+            let default_root = home.path().join(".local").join("share").join("Steam");
+            fs::create_dir_all(&default_root)?;
+            let library = home.path().join("ExternalLibrary");
+            write_vdf(&default_root, MTGA_APP_ID, &library)?;
+
+            let result = steam_libraries_for_appid_in(home.path(), MTGA_APP_ID);
+            assert_eq!(result, vec![library]);
+            Ok(())
+        }
+
+        #[test]
+        fn test_steam_libraries_for_appid_in_flatpak_root_vdf_match_returns_library() -> TestResult
+        {
+            let home = tempfile::tempdir()?;
+            let flatpak_root = home
+                .path()
+                .join(".var")
+                .join("app")
+                .join("com.valvesoftware.Steam")
+                .join(".local")
+                .join("share")
+                .join("Steam");
+            fs::create_dir_all(&flatpak_root)?;
+            let library = home.path().join("FlatpakLibrary");
+            write_vdf(&flatpak_root, MTGA_APP_ID, &library)?;
+
+            let result = steam_libraries_for_appid_in(home.path(), MTGA_APP_ID);
+            assert_eq!(result, vec![library]);
+            Ok(())
+        }
+
+        #[test]
+        fn test_steam_libraries_for_appid_in_deb_symlink_root_compatdata_fallback_returns_root(
+        ) -> TestResult {
+            let home = tempfile::tempdir()?;
+            // .deb installs live at ~/.steam/debian-installation, referenced
+            // via the ~/.steam/steam symlink.
+            let real_root = home.path().join(".steam").join("debian-installation");
+            fs::create_dir_all(&real_root)?;
+            write_compatdata(&real_root, MTGA_APP_ID)?;
+            symlink(&real_root, home.path().join(".steam").join("steam"))?;
+
+            let result = steam_libraries_for_appid_in(home.path(), MTGA_APP_ID);
+            let expected_root = fs::canonicalize(&real_root)?;
+            assert_eq!(result, vec![expected_root]);
+            Ok(())
+        }
+
+        #[test]
+        fn test_steam_libraries_for_appid_in_snap_root_compatdata_fallback_returns_root(
+        ) -> TestResult {
+            let home = tempfile::tempdir()?;
+            let snap_root = home
+                .path()
+                .join("snap")
+                .join("steam")
+                .join("common")
+                .join(".local")
+                .join("share")
+                .join("Steam");
+            fs::create_dir_all(&snap_root)?;
+            write_compatdata(&snap_root, MTGA_APP_ID)?;
+
+            let result = steam_libraries_for_appid_in(home.path(), MTGA_APP_ID);
+            let expected_root = fs::canonicalize(&snap_root)?;
+            assert_eq!(result, vec![expected_root]);
+            Ok(())
+        }
+
+        #[test]
+        fn test_steam_libraries_for_appid_in_symlinked_roots_dedup_returns_single_library(
+        ) -> TestResult {
+            let home = tempfile::tempdir()?;
+            let real_root = home.path().join("RealSteamInstall");
+            fs::create_dir_all(&real_root)?;
+            write_compatdata(&real_root, MTGA_APP_ID)?;
+
+            let dot_steam = home.path().join(".steam");
+            fs::create_dir_all(&dot_steam)?;
+            symlink(&real_root, dot_steam.join("root"))?;
+            symlink(&real_root, dot_steam.join("steam"))?;
+
+            let result = steam_libraries_for_appid_in(home.path(), MTGA_APP_ID);
+            // `.steam/root` and `.steam/steam` both resolve to the same real
+            // directory: probing must collapse them into a single library,
+            // not report it twice.
+            assert_eq!(result.len(), 1);
+            Ok(())
+        }
+
+        #[test]
+        fn test_steam_libraries_for_appid_in_no_roots_exist_returns_empty() -> TestResult {
+            let home = tempfile::tempdir()?;
+            let result = steam_libraries_for_appid_in(home.path(), MTGA_APP_ID);
+            assert!(result.is_empty());
+            Ok(())
+        }
+
+        #[test]
+        fn test_steam_libraries_for_appid_in_root_without_match_excluded_from_results() -> TestResult
+        {
+            let home = tempfile::tempdir()?;
+            let default_root = home.path().join(".local").join("share").join("Steam");
+            fs::create_dir_all(&default_root)?;
+            // VDF exists but has no entry for our appid, and no compatdata
+            // fallback directory either.
+            write_vdf(&default_root, 730, &home.path().join("OtherLibrary"))?;
+
+            let result = steam_libraries_for_appid_in(home.path(), MTGA_APP_ID);
+            assert!(result.is_empty());
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Generalize Linux Steam-root discovery to probe an ordered, canonicalized, deduplicated set of Steam roots (default, Flatpak, .deb symlink, Snap) instead of a single hardcoded `~/.local/share/Steam`.
- Return all matching libraries and emit one discovery candidate per library, plus the existing Lutris fallback.
- Select the freshest existing `Player.log` by mtime instead of first-exists, so a stale leftover log can no longer shadow the live one; log the selected path + mtime at INFO.

## Changes Made
- `steam_libraries_for_appid_in(home, appid) -> Vec<PathBuf>` (new, injectable-home testability seam) replaces `steam_library_for_appid`, probing `~/.steam/root`, `~/.steam/steam`, `~/.local/share/Steam`, the Flatpak path, and the Snap path — skipping roots that don't exist or fail to canonicalize, and deduplicating roots that canonicalize to the same real directory.
- `steam_libraries_for_appid(appid)` reads `$HOME` and delegates to the above.
- `linux_candidate_base_dirs(home, steam_libraries: &[PathBuf])` now takes a slice of discovered libraries (was `Option<&Path>`) and emits one `.../LocalLow` candidate per library, plus the Lutris fallback last.
- New `select_freshest_candidate` helper picks the candidate with the newest `Player.log` mtime; `resolve_base_dir`'s missing-path fallback still prefers the first Steam-derived candidate (or the Lutris path if no Steam library was found) to preserve the existing error surface.
- Consolidated the app id on the existing `MTGA_APP_ID` const (previously duplicated as a string literal).

## Testing
- New tempdir fixtures drive `steam_libraries_for_appid_in` end-to-end (real `libraryfolders.vdf` + compatdata trees) for the default, Flatpak, `.deb`-symlink, and Snap root layouts, plus a symlinked-root dedup case and a no-match/no-roots case.
- New tests for `select_freshest_candidate` cover no-match, single-candidate, and a stale-first/fresh-second ordering case (regression coverage for the old first-exists shadowing bug).
- Existing `linux_candidate_base_dirs` ordering tests rewritten for the one-candidate-per-library + trailing-fallback contract.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean, both natively and cross-compiled for `x86_64-unknown-linux-gnu` (this code is Linux-gated and only builds/runs on Linux; the Linux-specific test suite runs in CI, `ubuntu-latest`).

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)