### PR TITLE
chore: bump to v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.2] - 2026-07-05
+
+### Fixed
+
+- **Linux `Player.log` discovery: probe all common Steam install roots and
+  prefer the freshest log.** Discovery previously derived at most one Steam
+  candidate from a single hardcoded root (`~/.local/share/Steam`) and selected
+  the first candidate whose `Player.log` existed. It now probes an ordered,
+  canonicalized, de-duplicated set of Steam roots — the native
+  `~/.local/share/Steam`, the `~/.steam/root` and `~/.steam/steam` symlinks
+  (Debian `.deb` installs), and the Flatpak
+  (`~/.var/app/com.valvesoftware.Steam/…`) and Snap
+  (`~/snap/steam/common/…`) roots — so Flatpak / `.deb` / Snap installs are
+  discovered. Candidate selection now picks the freshest existing `Player.log`
+  by modification time instead of first-exists, so a stale leftover log (e.g.
+  in an abandoned Lutris prefix) can no longer silently shadow the live Steam
+  log; the selected path and its mtime are logged at INFO ([#272], [#273]).
+- **Scrubber: CRLF-terminated lines bypassing `$`-anchored scrub patterns.**
+  The pet-diagnostic deck-name line and the macOS Metal enumerated-device
+  hardware-fingerprint line anchored on a bare `\)$`; on `\r\n`-terminated
+  log lines (standard for Windows-written `Player.log` files) the `\r`
+  before the newline broke the match, leaving the field unscrubbed under
+  default options. Both patterns now capture-and-re-emit an optional
+  trailing `\r` so CRLF lines are scrubbed without normalizing the line
+  ending to LF-only. A repo-wide sweep confirmed these were the only two
+  `$`-anchored scrub patterns exposed to this issue. Verified against
+  the `manasight-corpus` real logs (41/55 files are CRLF-terminated;
+  198 pet-diagnostic deck-name lines leaked before this change; 0 after)
+  ([#270], [#271]).
+
+[#270]: https://github.com/manasight/manasight-parser/issues/270
+[#271]: https://github.com/manasight/manasight-parser/pull/271
+[#272]: https://github.com/manasight/manasight-parser/issues/272
+[#273]: https://github.com/manasight/manasight-parser/pull/273
+
 ## [0.7.0] - 2026-07-02
 
 ### Added
@@ -43,20 +78,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   any exhaustive struct literal (`ScrubOptions { keep_player_names: ... }`
   without `..Default::default()`) no longer compiles and must add the new
   field, or switch to `..Default::default()`.
-
-### Fixed
-
-- **Scrubber: CRLF-terminated lines bypassing `$`-anchored scrub patterns.**
-  The pet-diagnostic deck-name line and the macOS Metal enumerated-device
-  hardware-fingerprint line anchored on a bare `\)$`; on `\r\n`-terminated
-  log lines (standard for Windows-written `Player.log` files) the `\r`
-  before the newline broke the match, leaving the field unscrubbed under
-  default options. Both patterns now capture-and-re-emit an optional
-  trailing `\r` so CRLF lines are scrubbed without normalizing the line
-  ending to LF-only. A repo-wide sweep confirmed these were the only two
-  `$`-anchored scrub patterns exposed to this issue. Verified against
-  the `manasight-corpus` real logs (41/55 files are CRLF-terminated;
-  198 pet-diagnostic deck-name lines leaked before this change; 0 after).
 
 ## [0.6.3] - 2026-06-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "manasight-parser"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manasight-parser"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "MTG Arena log file parser — reads Player.log and emits typed game events"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or in `Cargo.toml`:
 
 ```toml
 [dependencies]
-manasight-parser = "0.6"
+manasight-parser = "0.7"
 ```
 
 Requires Rust 1.93.0 or later.


### PR DESCRIPTION
## Summary

- Bump `manasight-parser` from **0.7.0 (last published) → 0.7.2** for the next crates.io release.
- Patch release: no fully-public API changes since v0.7.0 — bundles the two bug fixes that landed on `main` after the 0.7.0 tag.
- The earlier `0.7.1` `Cargo.toml` bump (from the CRLF scrub fix) was never tagged or published, so `0.7.2` supersedes it.

## Changes since v0.7.0

**Fixed**
- Linux `Player.log` discovery: probe all common Steam install roots (native, `~/.steam/root` / `~/.steam/steam` symlinks, Flatpak, Snap) with canonicalize + dedup, and select the freshest existing log by mtime instead of first-exists so a stale log can't shadow the live one (#272, #273).
- Scrubber: CRLF-terminated lines no longer bypass `$`-anchored scrub patterns (#270, #271).

## CHANGELOG correction

- The CRLF scrub fix (#271) was mis-filed under `## [0.7.0]` (it landed after `v0.7.0` was tagged/published and was never released). Relocated it into the new `## [0.7.2]` section so the changelog reflects the release that actually ships it.
- README dependency pin refreshed `0.6` → `0.7`.

## Test plan

- [x] `cargo check` clean; `Cargo.lock` updated to 0.7.2
- [x] `cargo fmt --all -- --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features`: 1124 pass; the lone local failure is the known host-environment case (`test_discover_log_file_returns_error_in_ci`, real MTGA present on the dev Mac) — passes in CI; this PR changes no `.rs` files
- [ ] CI green
- [ ] After merge: tag `v0.7.2` and trigger the publish-crate workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)